### PR TITLE
Update ModernCapture.cs

### DIFF
--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/ModernCapture.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/ModernCapture.cs
@@ -1,0 +1,348 @@
+using System;
+using System.Drawing;
+using System.Reflection;
+using System.IO;
+using System.Threading;
+
+using Windows.Foundation.Metadata;
+using Windows.Graphics.Capture;
+using Windows.Graphics.DirectX.Direct3D11;
+
+using SharpDX;
+using D3D = SharpDX.Direct3D;
+using D3D11 = SharpDX.Direct3D11;
+using DXGI = SharpDX.DXGI;
+using WIC = SharpDX.WIC;
+using D3DCompiler = SharpDX.D3DCompiler;
+
+using ShareX.ScreenCaptureLib.AdvancedGraphics.Direct3D.Shaders;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.Direct3D
+{
+    public class ModernCaptureSignletonManager
+    {
+        private static ModernCaptureSignletonManager _instance = new ModernCaptureSignletonManager();
+        public static ModernCaptureSignletonManager Instance => _instance;
+
+        private SemaphoreSlim _sharedResourceSemaphore;
+        private ModernCapture _captureInstance;
+        private bool _apiFullFeatureAvailable;
+
+        public ModernCaptureSignletonManager()
+        {
+            _sharedResourceSemaphore = new SemaphoreSlim(1);
+            // It is possible to use this from 1903+, but cursor control is only added in 2004. Therefore
+            // the base requirement was raised to 2004.
+            _apiFullFeatureAvailable = ApiInformation.IsApiContractPresent("Windows.Foundation.UniversalApiContract", 10, 0);
+        }
+
+        public bool IsAvailable
+        {
+            get
+            {
+                return _apiFullFeatureAvailable;
+            }
+        }
+
+        public ModernCapture Take()
+        {
+            _sharedResourceSemaphore.Wait();
+            if (_captureInstance == null)
+            {
+                _captureInstance = new ModernCapture();
+            }
+            return _captureInstance;
+        }
+
+        public void Release()
+        {
+            _sharedResourceSemaphore.Release();
+        }
+    }
+
+    public class ModernCapture : IDisposable
+    {
+        private ModernCaptureItemDescription description;
+
+        private IDirect3DDevice wrtD3D11Device;
+        private D3D11.Device d3dDevice;
+        private D3D11.DeviceContext d3dContext;
+
+        private D3D11.VertexShader vsQuad;
+        private D3DCompiler.ShaderSignature shaderInputSigVsQuad;
+        private D3D11.InputElement[] shaderInputElements = new D3D11.InputElement[]
+        {
+            new D3D11.InputElement("POSITION", 0, DXGI.Format.R32G32B32_Float, 0),
+            new D3D11.InputElement("TEXCOORD", 0, DXGI.Format.R32G32_Float, 0)
+        };
+        private D3D11.InputLayout inputLayout;
+
+        private D3D11.PixelShader psToneMapping;
+        private D3D11.SamplerState samplerState;
+
+        private D3D11.Texture2D textureSDRImage;
+        private D3D11.RenderTargetView rtvSdrTexture;
+
+        private WIC.ImagingFactory2 wicFactory;
+
+        private ModernCaptureMonitorSession currentSession;
+
+        public ModernCapture()
+        {
+#if DEBUG
+            // Check memory leaks in debug config
+            Configuration.EnableObjectTracking = true;
+#endif
+
+            wrtD3D11Device = Direct3D11Helper.CreateDevice();
+            d3dDevice = Direct3D11Helper.CreateSharpDXDevice(wrtD3D11Device);
+            d3dContext = d3dDevice.ImmediateContext;
+            wicFactory = new WIC.ImagingFactory2();
+
+            InitializeShaders();
+            InitializeSharedComponents();
+        }
+
+        public Bitmap CaptureAndProcess(ModernCaptureItemDescription itemDescription)
+        {
+            // Assuming old texture is already disposed
+            description = itemDescription;
+
+            // Initialize DirectX context (for the canvas)
+            textureSDRImage = new D3D11.Texture2D(d3dDevice, new D3D11.Texture2DDescription
+            {
+                Width = description.CanvasRect.Width,
+                Height = description.CanvasRect.Height,
+                MipLevels = 1,
+                ArraySize = 1,
+                Format = DXGI.Format.B8G8R8A8_UNorm_SRgb,
+                Usage = D3D11.ResourceUsage.Default,
+                SampleDescription = new DXGI.SampleDescription(1, 0),
+                BindFlags = D3D11.BindFlags.RenderTarget,
+                CpuAccessFlags = D3D11.CpuAccessFlags.None,
+                OptionFlags = D3D11.ResourceOptionFlags.None,
+            });
+            rtvSdrTexture = new D3D11.RenderTargetView(d3dDevice, textureSDRImage);
+
+            d3dContext.Rasterizer.SetViewport(new Viewport(0, 0, description.CanvasRect.Width, description.CanvasRect.Height));
+            d3dContext.OutputMerger.SetRenderTargets(rtvSdrTexture);
+            d3dContext.ClearRenderTargetView(rtvSdrTexture, new SharpDX.Mathematics.Interop.RawColor4 { A = 0.0f, B = 0.0f, G = 0.0f, R = 0.0f });
+
+            foreach (var item in description.Regions)
+            {
+                using (var session = new ModernCaptureMonitorSession(wrtD3D11Device, item))
+                {
+                    Direct3D11CaptureFrame f;
+                    currentSession = session;
+                    session.Session.StartCapture();
+                    while ((f = session.FramePool.TryGetNextFrame()) == null)
+                    {
+                        Thread.Sleep(1);
+                    }
+                    ProcessFrame(f);
+                    f.Dispose();
+                }
+            }
+
+            // Process final 8-bit bitmap
+            var gdiPlusBitmap = new Bitmap(DumpAndSaveImage());
+            rtvSdrTexture.Dispose();
+            textureSDRImage.Dispose();
+            description = null;
+
+#if DEBUG
+            System.Diagnostics.Debug.WriteLine(SharpDX.Diagnostics.ObjectTracker.ReportActiveObjects());
+#endif
+            return gdiPlusBitmap;
+        }
+
+        private void InitializeSharedComponents()
+        {
+            inputLayout = new D3D11.InputLayout(d3dDevice, shaderInputSigVsQuad, shaderInputElements);
+            samplerState = new D3D11.SamplerState(d3dDevice, new D3D11.SamplerStateDescription
+            {
+                AddressU = D3D11.TextureAddressMode.Wrap,
+                AddressV = D3D11.TextureAddressMode.Wrap,
+                AddressW = D3D11.TextureAddressMode.Wrap,
+                MinimumLod = 0,
+                MipLodBias = 0.0f,
+                MaximumLod = float.MaxValue,
+                BorderColor = new SharpDX.Mathematics.Interop.RawColor4(0.0f, 0.0f, 0.0f, 0.0f),
+                Filter = D3D11.Filter.MinMagMipLinear,
+            });
+        }
+
+        private void InitializeShaders()
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            using (var vxShaderStream = assembly.GetManifestResourceStream($"{ShaderConstant.ResourcePrefix}.PostProcessingQuad.cso"))
+            using (var psShaderStream = assembly.GetManifestResourceStream($"{ShaderConstant.ResourcePrefix}.PostProcessingColor.cso"))
+            {
+                using (var vbc = D3DCompiler.ShaderBytecode.FromStream(vxShaderStream))
+                using (var pbcTm = D3DCompiler.ShaderBytecode.FromStream(psShaderStream))
+                {
+                    psToneMapping = new D3D11.PixelShader(d3dDevice, pbcTm);
+                    vsQuad = new D3D11.VertexShader(d3dDevice, vbc);
+                    shaderInputSigVsQuad = D3DCompiler.ShaderSignature.GetInputSignature(vbc);
+                }
+            }
+        }
+
+        private Stream DumpAndSaveImage()
+        {
+            var stream = new MemoryStream();
+            var textureSDRCpuCopy = new D3D11.Texture2D(d3dDevice, new D3D11.Texture2DDescription
+            {
+                Width = description.CanvasRect.Width,
+                Height = description.CanvasRect.Height,
+                MipLevels = 1,
+                ArraySize = 1,
+                Format = DXGI.Format.B8G8R8A8_UNorm_SRgb,
+                Usage = D3D11.ResourceUsage.Staging,
+                SampleDescription = new DXGI.SampleDescription(1, 0),
+                BindFlags = D3D11.BindFlags.None,
+                CpuAccessFlags = D3D11.CpuAccessFlags.Read,
+                OptionFlags = D3D11.ResourceOptionFlags.None,
+            });
+
+            DataStream rawSdrImageDataStream;
+            d3dContext.CopyResource(textureSDRImage, textureSDRCpuCopy);
+
+            var dataBox = d3dContext.MapSubresource(textureSDRCpuCopy, 0, 0, D3D11.MapMode.Read, D3D11.MapFlags.None, out rawSdrImageDataStream);
+            var dataRectangle = new DataRectangle
+            {
+                DataPointer = rawSdrImageDataStream.DataPointer,
+                Pitch = dataBox.RowPitch,
+            };
+
+            using (var bitmap = new WIC.Bitmap(wicFactory, description.CanvasRect.Width, description.CanvasRect.Height, WIC.PixelFormat.Format32bppBGRA, dataRectangle))
+            using (var imageEncoder = new WIC.BmpBitmapEncoder(wicFactory, stream))
+            using (var encodeInstance = new WIC.BitmapFrameEncode(imageEncoder))
+            {
+                encodeInstance.Initialize();
+                encodeInstance.SetSize(bitmap.Size.Width, bitmap.Size.Height);
+                var pixelFormat = WIC.PixelFormat.Format24bppBGR;
+                encodeInstance.SetPixelFormat(ref pixelFormat);
+                encodeInstance.WriteSource(bitmap);
+                encodeInstance.Commit();
+                imageEncoder.Commit();
+                stream.Flush();
+            }
+
+            d3dContext.UnmapSubresource(textureSDRCpuCopy, 0);
+            rawSdrImageDataStream.Dispose();
+            textureSDRCpuCopy.Dispose();
+
+            return stream;
+        }
+
+        private void ProcessFrame(Direct3D11CaptureFrame frame)
+        {
+            // Do proecssing
+            using (frame)
+            {
+                using (var texture = Direct3D11Helper.CreateSharpDXTexture2D(frame.Surface))
+                {
+                    var hdrMetadata = currentSession.HdrMetadata;
+                    var vertices = new ShaderInputStructure[]
+                    {
+                            // Left-Top
+                            new ShaderInputStructure {
+                                Position = new Vector3(currentSession.DestD3DVsTopLeft.X, currentSession.DestD3DVsTopLeft.Y, 0),
+                                TextureCoord = new Vector2(currentSession.DestD3DPsSamplerTopLeft.X, currentSession.DestD3DPsSamplerTopLeft.Y),
+                            },
+                            // Right-Top
+                            new ShaderInputStructure {
+                                Position = new Vector3(currentSession.DestD3DVsBottomRight.X, currentSession.DestD3DVsTopLeft.Y, 0),
+                                TextureCoord = new Vector2(currentSession.DestD3DPsSamplerBottomRight.X, currentSession.DestD3DPsSamplerTopLeft.Y)
+                            },
+                            // Left-Bottom
+                            new ShaderInputStructure {
+                                Position = new Vector3(currentSession.DestD3DVsTopLeft.X, currentSession.DestD3DVsBottomRight.Y, 0),
+                                TextureCoord = new Vector2(currentSession.DestD3DPsSamplerTopLeft.X, currentSession.DestD3DPsSamplerBottomRight.Y)
+                            },
+                            // Right-Top
+                            new ShaderInputStructure {
+                                Position = new Vector3(currentSession.DestD3DVsBottomRight.X, currentSession.DestD3DVsTopLeft.Y, 0),
+                                TextureCoord = new Vector2(currentSession.DestD3DPsSamplerBottomRight.X, currentSession.DestD3DPsSamplerTopLeft.Y)
+                            },
+                            // Right-Bottom
+                            new ShaderInputStructure {
+                                Position = new Vector3(currentSession.DestD3DVsBottomRight.X, currentSession.DestD3DVsBottomRight.Y, 0),
+                                TextureCoord = new Vector2(currentSession.DestD3DPsSamplerBottomRight.X, currentSession.DestD3DPsSamplerBottomRight.Y)
+                            },
+                            // Left-Bottom
+                            new ShaderInputStructure {
+                                Position = new Vector3(currentSession.DestD3DVsTopLeft.X, currentSession.DestD3DVsBottomRight.Y, 0),
+                                TextureCoord = new Vector2(currentSession.DestD3DPsSamplerTopLeft.X, currentSession.DestD3DPsSamplerBottomRight.Y)
+                            },
+                    };
+
+                    var triangleVertexBuffer = D3D11.Buffer.Create(d3dDevice, D3D11.BindFlags.VertexBuffer, vertices);
+                    var hdrMetadataBuffer = new D3D11.Buffer(d3dDevice,
+                        Utilities.SizeOf<ShaderHdrMetadata>(),
+                        D3D11.ResourceUsage.Default,
+                        D3D11.BindFlags.ConstantBuffer,
+                        D3D11.CpuAccessFlags.None,
+                        D3D11.ResourceOptionFlags.None,
+                        0);
+
+                    d3dContext.UpdateSubresource(ref hdrMetadata, hdrMetadataBuffer);
+
+                    d3dContext.InputAssembler.PrimitiveTopology = D3D.PrimitiveTopology.TriangleList;
+                    d3dContext.InputAssembler.InputLayout = inputLayout;
+                    d3dContext.InputAssembler.SetVertexBuffers(0, new D3D11.VertexBufferBinding(triangleVertexBuffer, Utilities.SizeOf<ShaderInputStructure>(), 0));
+
+                    d3dContext.VertexShader.Set(vsQuad);
+                    d3dContext.PixelShader.SetConstantBuffer(0, hdrMetadataBuffer);
+                    d3dContext.PixelShader.SetSampler(0, samplerState);
+
+                    var canvasTexture = new D3D11.Texture2D(d3dDevice, new D3D11.Texture2DDescription
+                    {
+                        Width = texture.Description.Width,
+                        Height = texture.Description.Height,
+                        MipLevels = 1,
+                        ArraySize = 1,
+                        Format = currentSession.HdrMetadata.EnableHdrProcessing ? DXGI.Format.R16G16B16A16_Float : DXGI.Format.B8G8R8A8_UNorm_SRgb,
+                        Usage = D3D11.ResourceUsage.Default,
+                        SampleDescription = new DXGI.SampleDescription(1, 0),
+                        BindFlags = D3D11.BindFlags.ShaderResource,
+                        CpuAccessFlags = D3D11.CpuAccessFlags.None,
+                        OptionFlags = D3D11.ResourceOptionFlags.None,
+                    });
+
+                    using (canvasTexture)
+                    using (var shaderResView = new D3D11.ShaderResourceView(d3dDevice, canvasTexture))
+                    {
+                        d3dContext.CopyResource(texture, canvasTexture);
+                        d3dContext.PixelShader.SetShaderResource(0, shaderResView);
+                        d3dContext.PixelShader.Set(psToneMapping);
+                        d3dContext.Draw(vertices.Length, 0);
+                    }
+
+                    triangleVertexBuffer.Dispose();
+                    hdrMetadataBuffer.Dispose();
+                }
+            }
+
+            // Cleanup and signal event to proceed
+            currentSession.Session.Dispose();
+        }
+
+        public void Dispose()
+        {
+            rtvSdrTexture?.Dispose();
+            textureSDRImage?.Dispose();
+
+            inputLayout.Dispose();
+            samplerState.Dispose();
+            shaderInputSigVsQuad.Dispose();
+            psToneMapping.Dispose();
+            vsQuad.Dispose();
+
+            wrtD3D11Device.Dispose();
+            d3dDevice.Dispose();
+            wicFactory.Dispose();
+        }
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/ModernCapture.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/ModernCapture.cs
@@ -134,6 +134,7 @@ namespace ShareX.ScreenCaptureLib.AdvancedGraphics.Direct3D
                 {
                     Direct3D11CaptureFrame f;
                     currentSession = session;
+                    currentSession.Session.IsBorderRequired = false;
                     session.Session.StartCapture();
                     while ((f = session.FramePool.TryGetNextFrame()) == null)
                     {
@@ -238,6 +239,7 @@ namespace ShareX.ScreenCaptureLib.AdvancedGraphics.Direct3D
 
         private void ProcessFrame(Direct3D11CaptureFrame frame)
         {
+            currentSession.Session.IsBorderRequired = false;
             // Do proecssing
             using (frame)
             {

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/ModernCaptureMonitorSession.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/ModernCaptureMonitorSession.cs
@@ -1,0 +1,49 @@
+using System;
+using Windows.Graphics.Capture;
+using Windows.Graphics.DirectX;
+using Windows.Graphics.DirectX.Direct3D11;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.Direct3D
+{
+    class ModernCaptureMonitorSession : ModernCaptureMonitorDescription, IDisposable
+    {
+        private bool disposedValue;
+
+        public GraphicsCaptureItem CaptureItem { get; set; }
+        public Direct3D11CaptureFramePool FramePool { get; set; }
+        public GraphicsCaptureSession Session { get; set; }
+
+        public ModernCaptureMonitorSession(IDirect3DDevice device, ModernCaptureMonitorDescription description) : base(description)
+        {
+            this.CaptureItem = WinRTCaptureHelper.CreateItemForMonitor(description.MonitorInfo.Hmon);
+            this.FramePool = Direct3D11CaptureFramePool.Create(device,
+                description.HdrMetadata.EnableHdrProcessing ? DirectXPixelFormat.R16G16B16A16Float : DirectXPixelFormat.B8G8R8A8UIntNormalized,
+                2, CaptureItem.Size);
+            this.Session = FramePool.CreateCaptureSession(CaptureItem);
+            this.Session.IsCursorCaptureEnabled = description.CaptureCursor;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    Session?.Dispose();
+                    FramePool?.Dispose();
+                }
+
+                Session = null;
+                FramePool = null;
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/ColorSpace.hlsl
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/ColorSpace.hlsl
@@ -1,0 +1,73 @@
+// A few color space utilities
+
+float3 BiasX2(float3 x)
+{
+    return 2.0f * x - 1.0f;
+}
+
+float3 BiasD2(float3 x)
+{
+    return 0.5f * x + 0.5f;
+}
+
+// Christian Schuler, "Normal Mapping without Precomputed Tangents", ShaderX 5, Chapter 2.6, pp. 131-140
+// See also follow-up blog post: http://www.thetenthplanet.de/archives/1180
+float3x3 CalculateTBN(float3 p, float3 n, float2 tex)
+{
+    float3 dp1 = ddx(p);
+    float3 dp2 = ddy(p);
+    float2 duv1 = ddx(tex);
+    float2 duv2 = ddy(tex);
+
+    float3x3 M = float3x3(dp1, dp2, cross(dp1, dp2));
+    float2x3 inverseM = float2x3(cross(M[1], M[2]), cross(M[2], M[0]));
+    float3 t = normalize(mul(float2(duv1.x, duv2.x), inverseM));
+    float3 b = normalize(mul(float2(duv1.y, duv2.y), inverseM));
+    return float3x3(t, b, n);
+}
+
+float3 PeturbNormal(float3 localNormal, float3 position, float3 normal, float2 texCoord)
+{
+    const float3x3 TBN = CalculateTBN(position, normal, texCoord);
+    return normalize(mul(localNormal, TBN));
+}
+
+float3 TwoChannelNormalX2(float2 normal)
+{
+    float2 xy = 2.0f * normal - 1.0f;
+    float z = sqrt(1 - dot(xy, xy));
+    return float3(xy.x, xy.y, z);
+}
+
+// HDR10 Media Profile
+// https://en.wikipedia.org/wiki/High-dynamic-range_video#HDR10
+
+// Color rotation matrix to rotate Rec.709 color primaries into Rec.2020
+static const float3x3 from709to2020 =
+{
+    { 0.6274040f, 0.3292820f, 0.0433136f },
+    { 0.0690970f, 0.9195400f, 0.0113612f },
+    { 0.0163916f, 0.0880132f, 0.8955950f }
+};
+
+static const float3x3 from2020to709 =
+{
+    { 1.6604910f, -0.5876411f, -0.0728499f },
+    { -0.1245505f, 1.1328999f, -0.0083494f },
+    { -0.0181508f, -0.1005789f, 1.1187297f }
+};
+
+// Apply the ST.2084 curve to normalized linear values and outputs normalized non-linear values
+float3 LinearToST2084(float3 normalizedLinearValue)
+{
+    return pow((0.8359375f + 18.8515625f * pow(abs(normalizedLinearValue), 0.1593017578f)) / (1.0f + 18.6875f * pow(abs(normalizedLinearValue), 0.1593017578f)), 78.84375f);
+}
+
+// ST.2084 to linear, resulting in a linear normalized value
+float3 ST2084ToLinear(float3 ST2084)
+{
+    return pow(max(pow(abs(ST2084), 1.0f / 78.84375f) - 0.8359375f, 0.0f) / (18.8515625f - 18.6875f * pow(abs(ST2084), 1.0f / 78.84375f)), 1.0f / 0.1593017578f);
+}
+
+// Standard sRGB white point data
+static const float SRGB_D65_WHITE_POINT_NITS = 80.0f;

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/HLSLShaderIncludeHandler.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/HLSLShaderIncludeHandler.cs
@@ -1,0 +1,29 @@
+using SharpDX.D3DCompiler;
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.Direct3D.Shaders
+{
+    class HLSLShaderIncludeHandler : Include
+    {
+        public IDisposable Shadow { get; set; }
+
+        public void Close(Stream stream)
+        {
+            stream.Close();
+            stream.Dispose();
+        }
+
+        public void Dispose()
+        {
+            Shadow?.Dispose();
+        }
+
+        public Stream Open(IncludeType type, string fileName, Stream parentStream)
+        {
+            var assembly = Assembly.GetExecutingAssembly();
+            return assembly.GetManifestResourceStream($"{ShaderConstant.ResourcePrefix}.{fileName}");
+        }
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/PostProcessingColor.hlsl
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/PostProcessingColor.hlsl
@@ -1,0 +1,101 @@
+#include "ShaderInputStructure.hlsl"
+#include "ColorSpace.hlsl"
+
+Texture2D screenTexture : register(t0);
+SamplerState simpleSampler : register(s0);
+
+// Pass through from C# to configure the tone mapping process
+cbuffer HdrMetadata : register(b0)
+{
+    bool  EnableHdrProcessing;
+    float MonHdrDispNits;
+    float MonSdrDispNits;
+    float ExposureLevel;
+};
+
+// Reinhard tonemap operator
+// Reinhard et al. "Photographic tone reproduction for digital images." ACM Transactions on Graphics. 21. 2002.
+// http://www.cs.utah.edu/~reinhard/cdrom/tonemap.pdf
+float3 ToneMapReinhard(float3 color)
+{
+    return color / (1.0f + color);
+}
+
+// ACES Filmic tonemap operator
+// https://knarkowicz.wordpress.com/2016/01/06/aces-filmic-tone-mapping-curve/
+float3 ToneMapACESFilmic(float3 x)
+{
+    float a = 2.51f;
+    float b = 0.03f;
+    float c = 2.43f;
+    float d = 0.59f;
+    float e = 0.14f;
+    return saturate((x * (a * x + b)) / (x * (c * x + d) + e));
+}
+
+// Adjust input luminance based on monitor information.
+float3 TuneInputLuminance(float3 scRgbColor)
+{
+    return scRgbColor / (MonHdrDispNits / SRGB_D65_WHITE_POINT_NITS);
+}
+
+// Adjust output luminance based on monitor information.
+float3 TuneOutputLuminance(float3 scRgbColor)
+{
+    return scRgbColor * (MonSdrDispNits / SRGB_D65_WHITE_POINT_NITS);
+}
+
+// Perform transform processing for Windows HDR content.
+float4 PsWindowsHDR2SDR(VS_OUTPUT p) : SV_TARGET
+{
+    // Source -> EOTF -> Color Management -> InputLuminance ->
+    // Tonemap -> OutputLuminance -> Whitescale -> Destination
+    //
+    // EOTF is _possibly_ not required on every Windows HDR/WCG monitors.
+    // Some might just use DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709.
+    // Right now we assume DXGI_COLOR_SPACE_RGB_STUDIO_G2084_NONE_P2020
+    // until we have a way to determine DXGI colorspace in desktop apps.
+    //
+    // Luminance information is provided by system infra.
+
+    float4 hdr = screenTexture.Sample(simpleSampler, p.TexCoord);
+
+    // Convert to pure scRGB (DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709)
+    float3 eotf = ST2084ToLinear(hdr.xyz);
+    float3 scrgb = mul(from2020to709, eotf);
+
+    // Tone mapping
+    float3 sdr = TuneInputLuminance(hdr.xyz * ExposureLevel);
+    sdr = ToneMapReinhard(sdr);
+    sdr = TuneOutputLuminance(sdr);
+
+    // White scale fix-up
+    float scale = SRGB_D65_WHITE_POINT_NITS / MonSdrDispNits;
+    float3x3 whiteFixupMatrix =
+    {
+        { scale, 0, 0 },
+        { 0, scale, 0 },
+        { 0, 0, scale }
+    };
+
+    float3 sdrFixup = mul(whiteFixupMatrix, sdr);
+
+    // Return image
+    return float4(sdr, hdr.a);
+}
+
+// Passthrough pixel content
+float4 PsPassthrough(VS_OUTPUT p) : SV_TARGET
+{
+    return screenTexture.Sample(simpleSampler, p.TexCoord);
+}
+
+// For fxc
+float4 main(VS_OUTPUT p) : SV_TARGET
+{
+    if (EnableHdrProcessing) {
+        return PsWindowsHDR2SDR(p);
+    }
+
+    return PsPassthrough(p);
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/PostProcessingQuad.hlsl
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/PostProcessingQuad.hlsl
@@ -1,0 +1,16 @@
+#include "ShaderInputStructure.hlsl"
+
+VS_OUTPUT VxQuadEntry(VS_INPUT v)
+{
+    VS_OUTPUT vout;
+
+    vout.TexCoord = v.TexCoord;
+    vout.Position = v.Position;
+
+    return vout;
+}
+
+VS_OUTPUT main(VS_INPUT v)
+{
+    return VxQuadEntry(v);
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/ShaderConstant.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/ShaderConstant.cs
@@ -1,0 +1,7 @@
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.Direct3D.Shaders
+{
+    static class ShaderConstant
+    {
+        public static string ResourcePrefix => "D3D11Shaders";
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/ShaderInputStructure.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/ShaderInputStructure.cs
@@ -1,0 +1,10 @@
+using SharpDX;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.Direct3D.Shaders
+{
+    public struct ShaderInputStructure
+    {
+        public Vector3 Position;
+        public Vector2 TextureCoord;
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/ShaderInputStructure.hlsl
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/Shaders/ShaderInputStructure.hlsl
@@ -1,0 +1,11 @@
+struct VS_INPUT
+{
+    float4 Position : POSITION;
+    float2 TexCoord : TEXCOORD;
+};
+
+struct VS_OUTPUT
+{
+    float4 Position : SV_POSITION;
+    float2 TexCoord : TEXCOORD0;
+};

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/WinRTCaptureHelper.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/WinRTCaptureHelper.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Graphics.Capture;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.Direct3D
+{
+    public static class WinRTCaptureHelper
+    {
+        public static Guid GraphicsCaptureItemGuid => new Guid("79C3F95B-31F7-4EC2-A464-632EF5D30760");
+
+        [ComImport]
+        [Guid("3628E81B-3CAC-4C60-B7F4-23CE0E0C3356")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        [ComVisible(true)]
+        interface IGraphicsCaptureItemInterop
+        {
+            IntPtr CreateForWindow(
+                [In] IntPtr window,
+                [In] ref Guid iid);
+
+            IntPtr CreateForMonitor(
+                [In] IntPtr monitor,
+                [In] ref Guid iid);
+        }
+
+        public static GraphicsCaptureItem CreateItemForMonitor(IntPtr hmon)
+        {
+            var factory = WindowsRuntimeMarshal.GetActivationFactory(typeof(GraphicsCaptureItem));
+            var interop = (IGraphicsCaptureItemInterop)factory;
+            var temp = typeof(GraphicsCaptureItem);
+            var itemPointer = interop.CreateForMonitor(hmon, GraphicsCaptureItemGuid);
+            var item = Marshal.GetObjectForIUnknown(itemPointer) as GraphicsCaptureItem;
+            Marshal.Release(itemPointer);
+
+            return item;
+        }
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/WinRTD3D11Helper.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/Direct3D/WinRTD3D11Helper.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Runtime.InteropServices;
+using Windows.Graphics.DirectX.Direct3D11;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.Direct3D
+{
+    public static class Direct3D11Helper
+    {
+        public static Guid IInspectable => new Guid("AF86E2E0-B12D-4c6a-9C5A-D7AA65101E90");
+        public static Guid ID3D11Resource => new Guid("dc8e63f3-d12b-4952-b47b-5e45026a862d");
+        public static Guid IDXGIAdapter3 => new Guid("645967A4-1392-4310-A798-8053CE3E93FD");
+        public static Guid ID3D11Device => new Guid("db6f6ddb-ac77-4e88-8253-819df9bbf140");
+        public static Guid ID3D11Texture2D => new Guid("6f15aaf2-d208-4e89-9ab4-489535d34f9c");
+
+        [ComImport]
+        [Guid("A9B3D012-3DF2-4EE3-B8D1-8695F457D3C1")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        [ComVisible(true)]
+        interface IDirect3DDxgiInterfaceAccess
+        {
+            IntPtr GetInterface([In] ref Guid iid);
+        }
+
+        [DllImport(
+            "d3d11.dll",
+            EntryPoint = "CreateDirect3D11DeviceFromDXGIDevice",
+            SetLastError = true,
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true,
+            CallingConvention = CallingConvention.StdCall
+            )]
+        static extern UInt32 CreateDirect3D11DeviceFromDXGIDevice(IntPtr dxgiDevice, out IntPtr graphicsDevice);
+
+        [DllImport(
+            "d3d11.dll",
+            EntryPoint = "CreateDirect3D11SurfaceFromDXGISurface",
+            SetLastError = true,
+            CharSet = CharSet.Unicode,
+            ExactSpelling = true,
+            CallingConvention = CallingConvention.StdCall
+            )]
+        static extern UInt32 CreateDirect3D11SurfaceFromDXGISurface(IntPtr dxgiSurface, out IntPtr graphicsSurface);
+
+        public static IDirect3DDevice CreateDevice()
+        {
+            return CreateDevice(false);
+        }
+
+        public static IDirect3DDevice CreateDevice(bool useWARP)
+        {
+            var d3dDevice = new SharpDX.Direct3D11.Device(
+                useWARP ? SharpDX.Direct3D.DriverType.Software : SharpDX.Direct3D.DriverType.Hardware,
+                SharpDX.Direct3D11.DeviceCreationFlags.BgraSupport);
+            var device = CreateDirect3DDeviceFromSharpDXDevice(d3dDevice);
+            return device;
+        }
+
+        public static IDirect3DDevice CreateDirect3DDeviceFromSharpDXDevice(SharpDX.Direct3D11.Device d3dDevice)
+        {
+            IDirect3DDevice device = null;
+
+            // Acquire the DXGI interface for the Direct3D device.
+            using (var dxgiDevice = d3dDevice.QueryInterface<SharpDX.DXGI.Device3>())
+            {
+                // Wrap the native device using a WinRT interop object.
+                uint hr = CreateDirect3D11DeviceFromDXGIDevice(dxgiDevice.NativePointer, out IntPtr pUnknown);
+
+                if (hr == 0)
+                {
+                    device = Marshal.GetObjectForIUnknown(pUnknown) as IDirect3DDevice;
+                    Marshal.Release(pUnknown);
+                }
+            }
+
+            return device;
+        }
+
+        public static IDirect3DSurface CreateDirect3DSurfaceFromSharpDXTexture(SharpDX.Direct3D11.Texture2D texture)
+        {
+            IDirect3DSurface surface = null;
+
+            // Acquire the DXGI interface for the Direct3D surface.
+            using (var dxgiSurface = texture.QueryInterface<SharpDX.DXGI.Surface>())
+            {
+                // Wrap the native device using a WinRT interop object.
+                uint hr = CreateDirect3D11SurfaceFromDXGISurface(dxgiSurface.NativePointer, out IntPtr pUnknown);
+
+                if (hr == 0)
+                {
+                    surface = Marshal.GetObjectForIUnknown(pUnknown) as IDirect3DSurface;
+                    Marshal.Release(pUnknown);
+                }
+            }
+
+            return surface;
+        }
+
+        public static SharpDX.Direct3D11.Device CreateSharpDXDevice(IDirect3DDevice device)
+        {
+            var access = (IDirect3DDxgiInterfaceAccess)device;
+            var d3dPointer = access.GetInterface(ID3D11Device);
+            var d3dDevice = new SharpDX.Direct3D11.Device(d3dPointer);
+            return d3dDevice;
+        }
+
+        public static SharpDX.Direct3D11.Texture2D CreateSharpDXTexture2D(IDirect3DSurface surface)
+        {
+            var access = (IDirect3DDxgiInterfaceAccess)surface;
+            var d3dPointer = access.GetInterface(ID3D11Texture2D);
+            var d3dSurface = new SharpDX.Direct3D11.Texture2D(d3dPointer);
+            return d3dSurface;
+        }
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/2DStructs.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/2DStructs.cs
@@ -1,0 +1,20 @@
+using System.Runtime.InteropServices;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.GDI
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct POINT
+    {
+        public int x;
+        public int y;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT
+    {
+        public int left;
+        public int top;
+        public int right;
+        public int bottom;
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/DisplayConfig.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/DisplayConfig.cs
@@ -1,0 +1,311 @@
+using System;
+
+using System.Runtime.InteropServices;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.GDI
+{
+    [Flags]
+    public enum QDC_CONSTANT : uint
+    {
+        QDC_ALL_PATHS = 0x1,
+        QDC_ONLY_ACTIVE_PATHS = 0x2,
+        QDC_DATABASE_CURRENT = 0x4,
+        QDC_VIRTUAL_MODE_AWARE = 0x10,
+        QDC_INCLUDE_HMD = 0x20,
+    }
+
+    public enum DISPLAYCONFIG_DEVICE_INFO_TYPE : uint
+    {
+        DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME = 1,
+        DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME = 2,
+        DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_PREFERRED_MODE = 3,
+        DISPLAYCONFIG_DEVICE_INFO_GET_ADAPTER_NAME = 4,
+        DISPLAYCONFIG_DEVICE_INFO_SET_TARGET_PERSISTENCE = 5,
+        DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_BASE_TYPE = 6,
+        DISPLAYCONFIG_DEVICE_INFO_GET_SUPPORT_VIRTUAL_RESOLUTION = 7,
+        DISPLAYCONFIG_DEVICE_INFO_SET_SUPPORT_VIRTUAL_RESOLUTION = 8,
+        DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO = 9,
+        DISPLAYCONFIG_DEVICE_INFO_SET_ADVANCED_COLOR_STATE = 10,
+        DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL = 11,
+        DISPLAYCONFIG_DEVICE_INFO_FORCE_UINT32 = 0xFFFFFFFF,
+    }
+
+    public enum DISPLAYCONFIG_COLOR_ENCODING : uint
+    {
+        DISPLAYCONFIG_COLOR_ENCODING_RGB = 0,
+        DISPLAYCONFIG_COLOR_ENCODING_YCBCR444 = 1,
+        DISPLAYCONFIG_COLOR_ENCODING_YCBCR422 = 2,
+        DISPLAYCONFIG_COLOR_ENCODING_YCBCR420 = 3,
+        DISPLAYCONFIG_COLOR_ENCODING_INTENSITY = 4,
+        DISPLAYCONFIG_COLOR_ENCODING_FORCE_UINT32 = 0xFFFFFFFF,
+    }
+
+    [Flags]
+    public enum DISPLAYCONFIG_PATH_SOURCE_INFO_FLAGS
+    {
+        None = 0,
+        DISPLAYCONFIG_SOURCE_IN_USE = 1,
+    }
+
+    public enum DISPLAYCONFIG_MODE_INFO_TYPE
+    {
+        DISPLAYCONFIG_MODE_INFO_TYPE_FORCE_UINT32 = -1,
+        DISPLAYCONFIG_MODE_INFO_TYPE_SOURCE = 1,
+        DISPLAYCONFIG_MODE_INFO_TYPE_TARGET = 2,
+        DISPLAYCONFIG_MODE_INFO_TYPE_DESKTOP_IMAGE = 3,
+    }
+
+    [Flags]
+    public enum DISPLAYCONFIG_PATH_TARGET_INFO_FLAGS
+    {
+        None = 0,
+        DISPLAYCONFIG_TARGET_IN_USE = 1,
+        DISPLAYCONFIG_TARGET_FORCIBLE = 2,
+        DISPLAYCONFIG_TARGET_FORCED_AVAILABILITY_BOOT = 4,
+        DISPLAYCONFIG_TARGET_FORCED_AVAILABILITY_PATH = 8,
+        DISPLAYCONFIG_TARGET_FORCED_AVAILABILITY_SYSTEM = 16,
+    }
+
+    public enum DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY
+    {
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_INTERNAL = int.MinValue,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_OTHER = -1,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_FORCE_UINT32 = -1,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_HD15 = 0,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_SVIDEO = 1,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_COMPOSITE_VIDEO = 2,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_COMPONENT_VIDEO = 3,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_DVI = 4,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_HDMI = 5,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_LVDS = 6,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_D_JPN = 8,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_SDI = 9,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_DISPLAYPORT_EXTERNAL = 10,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_DISPLAYPORT_EMBEDDED = 11,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_UDI_EXTERNAL = 12,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_UDI_EMBEDDED = 13,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_SDTVDONGLE = 14,
+        DISPLAYCONFIG_OUTPUT_TECHNOLOGY_MIRACAST = 15,
+    }
+    public enum DISPLAYCONFIG_ROTATION
+    {
+        DISPLAYCONFIG_ROTATION_FORCE_UINT32 = -1,
+        DISPLAYCONFIG_ROTATION_IDENTITY = 1,
+        DISPLAYCONFIG_ROTATION_ROTATE90 = 2,
+        DISPLAYCONFIG_ROTATION_ROTATE180 = 3,
+        DISPLAYCONFIG_ROTATION_ROTATE270 = 4,
+    }
+
+    public enum DISPLAYCONFIG_SCANLINE_ORDERING
+    {
+        DISPLAYCONFIG_SCANLINE_ORDERING_FORCE_UINT32 = -1,
+        DISPLAYCONFIG_SCANLINE_ORDERING_UNSPECIFIED = 0,
+        DISPLAYCONFIG_SCANLINE_ORDERING_PROGRESSIVE = 1,
+        DISPLAYCONFIG_SCANLINE_ORDERING_INTERLACED = 2,
+        DISPLAYCONFIG_SCANLINE_ORDERING_INTERLACED_UPPERFIELDFIRST = 2,
+        DISPLAYCONFIG_SCANLINE_ORDERING_INTERLACED_LOWERFIELDFIRST = 3,
+    }
+
+    public enum DISPLAYCONFIG_SCALING
+    {
+        DISPLAYCONFIG_SCALING_FORCE_UINT32 = -1,
+        DISPLAYCONFIG_SCALING_IDENTITY = 1,
+        DISPLAYCONFIG_SCALING_CENTERED = 2,
+        DISPLAYCONFIG_SCALING_STRETCHED = 3,
+        DISPLAYCONFIG_SCALING_ASPECTRATIOCENTEREDMAX = 4,
+        DISPLAYCONFIG_SCALING_CUSTOM = 5,
+        DISPLAYCONFIG_SCALING_PREFERRED = 128,
+    }
+
+    [Flags]
+    public enum AdvancedColorStatus : uint
+    {
+        AdvancedColorNone = 0,
+        AdvancedColorSupported = 1 << 0,
+        AdvancedColorEnabled = 1 << 1,
+        WideColorEnforced = 1 << 2,
+        AdvancedColorForceDisabled = 1 << 3,
+    }
+
+    public enum DISPLAYCONFIG_PIXELFORMAT
+    {
+        DISPLAYCONFIG_PIXELFORMAT_FORCE_UINT32 = -1,
+        DISPLAYCONFIG_PIXELFORMAT_8BPP = 1,
+        DISPLAYCONFIG_PIXELFORMAT_16BPP = 2,
+        DISPLAYCONFIG_PIXELFORMAT_24BPP = 3,
+        DISPLAYCONFIG_PIXELFORMAT_32BPP = 4,
+        DISPLAYCONFIG_PIXELFORMAT_NONGDI = 5,
+    }
+
+    public enum DISPLAYCONFIG_PATH
+    {
+        DISPLAYCONFIG_PATH_ACTIVE = 0x00000001,
+        DISPLAYCONFIG_PATH_PREFERRED_UNSCALED = 0x00000004,
+        DISPLAYCONFIG_PATH_SUPPORT_VIRTUAL_MODE = 0x00000008,
+    }
+
+    public interface IDisplayConfigInfo
+    {
+        // Nothing here
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_DEVICE_INFO_HEADER : IDisplayConfigInfo
+    {
+        public DISPLAYCONFIG_DEVICE_INFO_TYPE type;
+        public uint size;
+        public LUID adapterId;
+        public uint id;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO : IDisplayConfigInfo
+    {
+        public DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+        public AdvancedColorStatus AdvancedColorStatus;
+        public DISPLAYCONFIG_COLOR_ENCODING ColorEncoding;
+        public uint BitsPerColorChannel;
+
+        public static DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO CreateGet()
+        {
+            DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO s = new DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO();
+            s.header.type = DISPLAYCONFIG_DEVICE_INFO_TYPE.DISPLAYCONFIG_DEVICE_INFO_GET_ADVANCED_COLOR_INFO;
+            s.header.size = (uint)Marshal.SizeOf(s);
+            return s;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_SDR_WHITE_LEVEL : IDisplayConfigInfo
+    {
+        public DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+        public uint SDRWhiteLevel;
+
+        public float SDRWhiteLevelInNits => (SDRWhiteLevel / 1000) * 80;
+
+        public static DISPLAYCONFIG_SDR_WHITE_LEVEL CreateGet()
+        {
+            DISPLAYCONFIG_SDR_WHITE_LEVEL s = new DISPLAYCONFIG_SDR_WHITE_LEVEL();
+            s.header.type = DISPLAYCONFIG_DEVICE_INFO_TYPE.DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL;
+            s.header.size = (uint)Marshal.SizeOf(s);
+            return s;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+    public struct DISPLAYCONFIG_SOURCE_DEVICE_NAME : IDisplayConfigInfo
+    {
+        public DISPLAYCONFIG_DEVICE_INFO_HEADER header;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = GdiInteropConstants.CCHDEVICENAME)]
+        public string DeviceName;
+
+        public static DISPLAYCONFIG_SOURCE_DEVICE_NAME CreateGet()
+        {
+            DISPLAYCONFIG_SOURCE_DEVICE_NAME s = new DISPLAYCONFIG_SOURCE_DEVICE_NAME();
+            s.header.type = DISPLAYCONFIG_DEVICE_INFO_TYPE.DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+            s.header.size = (uint)Marshal.SizeOf(s);
+            return s;
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_PATH_SOURCE_INFO
+    {
+        public LUID adapterId;
+        public uint id;
+        public uint modeInfoIdx;
+        public DISPLAYCONFIG_PATH_SOURCE_INFO_FLAGS statusFlags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_RATIONAL
+    {
+        public uint Numerator;
+        public uint Denominator;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_PATH_TARGET_INFO
+    {
+        public LUID adapterId;
+        public uint id;
+        public uint modeInfoIdx;
+        public DISPLAYCONFIG_VIDEO_OUTPUT_TECHNOLOGY outputTechnology;
+        public DISPLAYCONFIG_ROTATION rotation;
+        public DISPLAYCONFIG_SCALING scaling;
+        public DISPLAYCONFIG_RATIONAL refreshRate;
+        public DISPLAYCONFIG_SCANLINE_ORDERING scanLineOrdering;
+        public bool targetAvailable;
+        public DISPLAYCONFIG_PATH_TARGET_INFO_FLAGS statusFlags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_PATH_INFO
+    {
+        public DISPLAYCONFIG_PATH_SOURCE_INFO sourceInfo;
+        public DISPLAYCONFIG_PATH_TARGET_INFO targetInfo;
+        public DISPLAYCONFIG_PATH flags;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_2DREGION
+    {
+        public uint cx;
+        public uint cy;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_ADDITIONAL_SIGNAL_INFO
+    {
+        public ushort videoStandard;
+
+        public int vSyncFreqDivider { get; set; }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_VIDEO_SIGNAL_INFO
+    {
+        public ulong pixelRate;
+        public DISPLAYCONFIG_RATIONAL hSyncFreq;
+        public DISPLAYCONFIG_RATIONAL vSyncFreq;
+        public DISPLAYCONFIG_2DREGION activeSize;
+        public DISPLAYCONFIG_2DREGION totalSize;
+        public DISPLAYCONFIG_ADDITIONAL_SIGNAL_INFO AdditionalSignalInfo;
+        public uint videoStandard;
+        public DISPLAYCONFIG_SCANLINE_ORDERING scanLineOrdering;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_TARGET_MODE
+    {
+        public DISPLAYCONFIG_VIDEO_SIGNAL_INFO targetVideoSignalInfo;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_SOURCE_MODE
+    {
+        public uint width;
+        public uint height;
+        public DISPLAYCONFIG_PIXELFORMAT pixelFormat;
+        public POINT position;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_DESKTOP_IMAGE_INFO
+    {
+        public POINT PathSourceSize;
+        public RECT DesktopImageRegion;
+        public RECT DesktopImageClip;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct DISPLAYCONFIG_MODE_INFO
+    {
+        public DISPLAYCONFIG_MODE_INFO_TYPE infoType;
+        public uint id;
+        public LUID adapterId;
+        public DISPLAYCONFIG_TARGET_MODE targetMode;
+        public DISPLAYCONFIG_SOURCE_MODE sourceMode;
+        public DISPLAYCONFIG_DESKTOP_IMAGE_INFO desktopImageInfo;
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/GdiInterop.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/GdiInterop.cs
@@ -1,0 +1,53 @@
+using BetterWin32Errors;
+using System;
+using System.Runtime.InteropServices;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.GDI
+{
+    public static class GdiInterop
+    {
+        [DllImport("User32.dll")]
+        private static extern Win32Error DisplayConfigSetDeviceInfo(IntPtr requestPacket);
+        public static Win32Error DisplayConfigSetDeviceInfo<T>(ref T displayConfig)
+           where T : IDisplayConfigInfo
+        {
+            return WrapStructureAndCall(ref displayConfig, DisplayConfigSetDeviceInfo);
+        }
+
+        [DllImport("User32.dll")]
+        private static extern Win32Error DisplayConfigGetDeviceInfo(IntPtr targetDeviceName);
+        public static Win32Error DisplayConfigGetDeviceInfo<T>(ref T displayConfig)
+          where T : IDisplayConfigInfo
+        {
+            return WrapStructureAndCall(ref displayConfig, DisplayConfigGetDeviceInfo);
+        }
+
+        [DllImport("User32.dll")]
+        public static extern Win32Error GetDisplayConfigBufferSizes(QDC_CONSTANT flags,
+            ref uint numPathArrayElements, ref uint numModeInfoArrayElements);
+
+        [DllImport("User32.dll")]
+        public static extern unsafe Win32Error QueryDisplayConfig(
+           QDC_CONSTANT Flags,
+           ref uint pNumPathArrayElements,
+           [Out] DISPLAYCONFIG_PATH_INFO[] pPathInfoArray,
+           ref uint pNumModeInfoArrayElements,
+           [Out] DISPLAYCONFIG_MODE_INFO[] pModeInfoArray,
+           IntPtr pCurrentTopologyId);
+
+        public static Win32Error WrapStructureAndCall<T>(ref T displayConfig,
+            Func<IntPtr, Win32Error> func)
+            where T : IDisplayConfigInfo
+        {
+            var ptr = Marshal.AllocHGlobal(Marshal.SizeOf(displayConfig));
+            Marshal.StructureToPtr(displayConfig, ptr, false);
+
+            var retval = func(ptr);
+
+            displayConfig = (T)Marshal.PtrToStructure(ptr, displayConfig.GetType());
+
+            Marshal.FreeHGlobal(ptr);
+            return retval;
+        }
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/GdiInteropConstants.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/GdiInteropConstants.cs
@@ -1,0 +1,7 @@
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.GDI
+{
+    static class GdiInteropConstants
+    {
+        public const int CCHDEVICENAME = 32;
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/Luid.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/Luid.cs
@@ -1,0 +1,11 @@
+using System.Runtime.InteropServices;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.GDI
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct LUID
+    {
+        public uint LowPart;
+        public int HighPart;
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/MonitorEnumerationHelper.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/MonitorEnumerationHelper.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.GDI
+{
+    static class MonitorEnumerationHelper
+    {
+        delegate bool EnumMonitorsDelegate(IntPtr hMonitor, IntPtr hdcMonitor, ref RECT lprcMonitor, IntPtr dwData);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct RECT
+        {
+            public int left;
+            public int top;
+            public int right;
+            public int bottom;
+        }
+
+        private const int CCHDEVICENAME = 32;
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        internal struct MonitorInfoEx
+        {
+            public int Size;
+            public RECT Monitor;
+            public RECT WorkArea;
+            public uint Flags;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = CCHDEVICENAME)]
+            public string DeviceName;
+        }
+
+        [DllImport("user32.dll")]
+        static extern bool EnumDisplayMonitors(IntPtr hdc, IntPtr lprcClip, EnumMonitorsDelegate lpfnEnum, IntPtr dwData);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        public static extern bool GetMonitorInfo(IntPtr hMonitor, ref MonitorInfoEx lpmi);
+
+        public static IEnumerable<MonitorInfo> GetMonitors()
+        {
+            var result = new List<MonitorInfo>();
+
+            EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero,
+                delegate (IntPtr hMonitor, IntPtr hdcMonitor, ref RECT lprcMonitor, IntPtr dwData)
+                {
+                    MonitorInfoEx mi = new MonitorInfoEx();
+                    mi.Size = Marshal.SizeOf(mi);
+                    bool success = GetMonitorInfo(hMonitor, ref mi);
+                    if (success)
+                    {
+                        var info = new MonitorInfo
+                        {
+                            MonitorArea = new Rectangle(mi.Monitor.left, mi.Monitor.top, mi.Monitor.right - mi.Monitor.left, mi.Monitor.bottom - mi.Monitor.top),
+                            WorkArea = new Rectangle(mi.WorkArea.left, mi.WorkArea.top, mi.WorkArea.right - mi.WorkArea.left, mi.WorkArea.bottom - mi.WorkArea.top),
+                            IsPrimary = mi.Flags > 0,
+                            Hmon = hMonitor,
+                            DeviceName = mi.DeviceName,
+                        };
+                        result.Add(info);
+                    }
+                    return true;
+                }, IntPtr.Zero);
+            return result;
+        }
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/MonitorInfo.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/GDI/MonitorInfo.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Drawing;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics.GDI
+{
+    public class MonitorInfo
+    {
+        public bool IsPrimary { get; set; }
+        public Rectangle MonitorArea { get; set; }
+        public Rectangle WorkArea { get; set; }
+        public string DeviceName { get; set; }
+        public IntPtr Hmon { get; set; }
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/HdrMetadataUtility.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/HdrMetadataUtility.cs
@@ -1,0 +1,90 @@
+using System;
+using ShareX.ScreenCaptureLib.AdvancedGraphics.GDI;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics
+{
+    public static class HdrMetadataUtility
+    {
+        public static ShaderHdrMetadata GetTestSettings()
+        {
+            return new ShaderHdrMetadata { EnableHdrProcessing = true, MonHdrDispNits = 800.0f, MonSdrDispNits = 270.0f, ExposureLevel = 1.0f };
+        }
+
+        public static ShaderHdrMetadata GetHdrMetadataForMonitor(string deviceName)
+        {
+            var err = BetterWin32Errors.Win32Error.ERROR_SUCCESS;
+            // TODO: also query monitor HDR white point brightness (currently hardcoded to 800.0f)
+            var hdrMetadata = new ShaderHdrMetadata { EnableHdrProcessing = false, MonSdrDispNits = 80.0f, ExposureLevel = 1.0f, MonHdrDispNits = 800.0f };
+            var monAdvColorInfo = DISPLAYCONFIG_GET_ADVANCED_COLOR_INFO.CreateGet();
+            var monSdrWhiteLevel = DISPLAYCONFIG_SDR_WHITE_LEVEL.CreateGet();
+            uint numPathArrayElements = 0;
+            uint numModeInfoArrayElements = 0;
+
+            err = GdiInterop.GetDisplayConfigBufferSizes(QDC_CONSTANT.QDC_ONLY_ACTIVE_PATHS,
+                ref numPathArrayElements, ref numModeInfoArrayElements);
+            if (err != BetterWin32Errors.Win32Error.ERROR_SUCCESS)
+            {
+                throw new System.ComponentModel.Win32Exception((int)err);
+            }
+
+            var displayPathInfoArray = new DISPLAYCONFIG_PATH_INFO[numPathArrayElements];
+            var displayModeInfoArray = new DISPLAYCONFIG_MODE_INFO[numModeInfoArrayElements];
+
+            err = GdiInterop.QueryDisplayConfig(QDC_CONSTANT.QDC_ONLY_ACTIVE_PATHS,
+                    ref numPathArrayElements, displayPathInfoArray,
+                    ref numModeInfoArrayElements, displayModeInfoArray, IntPtr.Zero);
+            if (err != BetterWin32Errors.Win32Error.ERROR_SUCCESS)
+            {
+                throw new System.ComponentModel.Win32Exception((int)err);
+            }
+
+            for (uint pathIdx = 0; pathIdx < numPathArrayElements; pathIdx++)
+            {
+                DISPLAYCONFIG_SOURCE_DEVICE_NAME srcName = DISPLAYCONFIG_SOURCE_DEVICE_NAME.CreateGet();
+                srcName.header.adapterId.HighPart = displayPathInfoArray[pathIdx].sourceInfo.adapterId.HighPart;
+                srcName.header.adapterId.LowPart = displayPathInfoArray[pathIdx].sourceInfo.adapterId.LowPart;
+                srcName.header.id = displayPathInfoArray[pathIdx].sourceInfo.id;
+
+                err = GdiInterop.DisplayConfigGetDeviceInfo(ref srcName);
+                if (err != BetterWin32Errors.Win32Error.ERROR_SUCCESS)
+                {
+                    throw new System.ComponentModel.Win32Exception((int)err);
+                }
+
+                if (srcName.DeviceName == deviceName)
+                {
+                    // If matches, proceed to query color information
+                    monAdvColorInfo.header.adapterId.HighPart = displayPathInfoArray[pathIdx].targetInfo.adapterId.HighPart;
+                    monAdvColorInfo.header.adapterId.LowPart = displayPathInfoArray[pathIdx].targetInfo.adapterId.LowPart;
+                    monAdvColorInfo.header.id = displayPathInfoArray[pathIdx].targetInfo.id;
+
+                    monSdrWhiteLevel.header.adapterId.HighPart = displayPathInfoArray[pathIdx].targetInfo.adapterId.HighPart;
+                    monSdrWhiteLevel.header.adapterId.LowPart = displayPathInfoArray[pathIdx].targetInfo.adapterId.LowPart;
+                    monSdrWhiteLevel.header.id = displayPathInfoArray[pathIdx].targetInfo.id;
+
+                    err = GdiInterop.DisplayConfigGetDeviceInfo(ref monAdvColorInfo);
+                    if (err != BetterWin32Errors.Win32Error.ERROR_SUCCESS)
+                    {
+                        throw new System.ComponentModel.Win32Exception((int)err);
+                    }
+
+                    hdrMetadata.EnableHdrProcessing = (monAdvColorInfo.AdvancedColorStatus & AdvancedColorStatus.AdvancedColorEnabled) == AdvancedColorStatus.AdvancedColorEnabled;
+                    if (hdrMetadata.EnableHdrProcessing)
+                    {
+                        err = GdiInterop.DisplayConfigGetDeviceInfo(ref monSdrWhiteLevel);
+                        if (err != BetterWin32Errors.Win32Error.ERROR_SUCCESS)
+                        {
+                            throw new System.ComponentModel.Win32Exception((int)err);
+                        }
+
+                        hdrMetadata.MonSdrDispNits = monSdrWhiteLevel.SDRWhiteLevelInNits;
+                    }
+
+                    break;
+                }
+            }
+
+            return hdrMetadata;
+        }
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/ModernCaptureDescription.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/ModernCaptureDescription.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using ShareX.ScreenCaptureLib.AdvancedGraphics.GDI;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics
+{
+    public class ModernCaptureMonitorDescription
+    {
+        // For GDI use
+        public Rectangle DestGdiRect { get; set; }
+        public MonitorInfo MonitorInfo { get; set; }
+
+        // For DX use
+        public ShaderHdrMetadata HdrMetadata { get; set; }
+        public SharpDX.Vector2 DestD3DVsTopLeft { get; set; }
+        public SharpDX.Vector2 DestD3DVsBottomRight { get; set; }
+        public SharpDX.Vector2 DestD3DPsSamplerTopLeft { get; set; }
+        public SharpDX.Vector2 DestD3DPsSamplerBottomRight { get; set; }
+
+        // For WinRT use
+        public bool CaptureCursor { get; set; }
+
+        public ModernCaptureMonitorDescription()
+        {
+        }
+
+        public ModernCaptureMonitorDescription(ModernCaptureMonitorDescription d)
+        {
+            this.DestGdiRect = d.DestGdiRect;
+            this.MonitorInfo = d.MonitorInfo;
+            this.HdrMetadata = d.HdrMetadata;
+            this.DestD3DVsTopLeft = d.DestD3DVsTopLeft;
+            this.DestD3DVsBottomRight = d.DestD3DVsBottomRight;
+            this.DestD3DPsSamplerTopLeft = d.DestD3DPsSamplerTopLeft;
+            this.DestD3DPsSamplerBottomRight = d.DestD3DPsSamplerBottomRight;
+            this.CaptureCursor = d.CaptureCursor;
+        }
+    }
+
+    public class ModernCaptureItemDescription
+    {
+        public List<ModernCaptureMonitorDescription> Regions { get; private set; }
+        public Rectangle CanvasRect { get; private set; }
+        // Maps to (0,0) in DirectX coordinate system
+        public double CanvasMidPointX { get; set; }
+        public double CanvasMidPointY { get; set; }
+
+        private static void SamplerBoundCheck(float input)
+        {
+            if (input < 0 || input > 1) throw new InvalidCastException("Sampler region out of bound");
+        }
+
+        public ModernCaptureItemDescription(Rectangle canvas, List<ModernCaptureMonitorDescription> monRegions)
+        {
+            CanvasRect = canvas;
+            Regions = monRegions;
+
+            // Calculate (0, 0) location
+            CanvasMidPointX = CanvasRect.X + (CanvasRect.Width / 2.0);
+            CanvasMidPointY = CanvasRect.Y + (CanvasRect.Height / 2.0);
+
+            var widthHalf = CanvasRect.Width / 2.0;
+            var heightHalf = CanvasRect.Height / 2.0;
+
+            foreach (var region in Regions)
+            {
+                // Calculate Vertex Shader Location, reference coordinate system is the DX canvas center (0, 0)
+                var vtlX = (region.DestGdiRect.X - CanvasMidPointX) / widthHalf;
+                var vtlY = (CanvasMidPointY - region.DestGdiRect.Y) / heightHalf;
+                var vbrX = (region.DestGdiRect.X + region.DestGdiRect.Width - CanvasMidPointX) / widthHalf;
+                var vbrY = (CanvasMidPointY - region.DestGdiRect.Y - region.DestGdiRect.Height) / heightHalf;
+
+                region.DestD3DVsTopLeft = new SharpDX.Vector2((float) vtlX, (float) vtlY);
+                region.DestD3DVsBottomRight = new SharpDX.Vector2((float)vbrX, (float)vbrY);
+
+                // Calculate Pixel Shader Location, reference coordinate system is the top-left (X/Y) of this screen as (0, 0)
+                var ptlX = ((double) (region.DestGdiRect.X - region.MonitorInfo.MonitorArea.X)) / region.MonitorInfo.MonitorArea.Width;
+                var ptlY = ((double) (region.DestGdiRect.Y - region.MonitorInfo.MonitorArea.Y)) / region.MonitorInfo.MonitorArea.Height;
+                var pbrX = ((double) (region.DestGdiRect.X + region.DestGdiRect.Width - region.MonitorInfo.MonitorArea.X)) / region.MonitorInfo.MonitorArea.Width;
+                var pbrY = ((double) (region.DestGdiRect.Y + region.DestGdiRect.Height - region.MonitorInfo.MonitorArea.Y)) / region.MonitorInfo.MonitorArea.Height;
+
+                region.DestD3DPsSamplerTopLeft = new SharpDX.Vector2((float) ptlX, (float) ptlY);
+                region.DestD3DPsSamplerBottomRight = new SharpDX.Vector2((float) pbrX, (float) pbrY);
+
+                // Make sure they are not outbound
+                SamplerBoundCheck(region.DestD3DPsSamplerTopLeft.X);
+                SamplerBoundCheck(region.DestD3DPsSamplerTopLeft.Y);
+                SamplerBoundCheck(region.DestD3DPsSamplerBottomRight.X);
+                SamplerBoundCheck(region.DestD3DPsSamplerBottomRight.Y);
+            }
+        }
+    }
+}

--- a/ShareX.ScreenCaptureLib/AdvancedGraphics/ShaderHdrMetadata.cs
+++ b/ShareX.ScreenCaptureLib/AdvancedGraphics/ShaderHdrMetadata.cs
@@ -1,0 +1,13 @@
+using System.Runtime.InteropServices;
+
+namespace ShareX.ScreenCaptureLib.AdvancedGraphics
+{
+    [StructLayout(LayoutKind.Sequential)]
+    public struct ShaderHdrMetadata
+    {
+        public bool EnableHdrProcessing;
+        public float MonHdrDispNits;
+        public float MonSdrDispNits;
+        public float ExposureLevel;
+    }
+}

--- a/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
+++ b/ShareX.ScreenCaptureLib/ShareX.ScreenCaptureLib.csproj
@@ -3,16 +3,40 @@
     <TargetFramework>net48</TargetFramework>
     <OutputType>Library</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System.Design" />
+    <Reference Include="System.Design"/>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj" />
-    <ProjectReference Include="..\ShareX.ImageEffectsLib\ShareX.ImageEffectsLib.csproj" />
-    <ProjectReference Include="..\ShareX.MediaLib\ShareX.MediaLib.csproj" />
+    <ProjectReference Include="..\ShareX.HelpersLib\ShareX.HelpersLib.csproj"/>
+    <ProjectReference Include="..\ShareX.ImageEffectsLib\ShareX.ImageEffectsLib.csproj"/>
+    <ProjectReference Include="..\ShareX.MediaLib\ShareX.MediaLib.csproj"/>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ImageListView" Version="13.8.2" />
+    <PackageReference Include="BetterWin32Errors" Version="0.2.0"/>
+    <PackageReference Include="ImageListView" Version="13.8.2"/>
+    <PackageReference Include="Microsoft.HLSL.CSharpVB" Version="1.0.2"/>
+    <PackageReference Include="Microsoft.Windows.SDK.Contracts" Version="10.0.26100.1"/>
+    <PackageReference Include="SharpDX" Version="4.2.0"/>
+    <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0"/>
+    <PackageReference Include="SharpDX.Direct2D1" Version="4.2.0"/>
+    <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0"/>
+    <PackageReference Include="SharpDX.DXGI" Version="4.2.0" />
+    <PackageReference Include="SharpDX.Mathematics" Version="4.2.0"/>
+  </ItemGroup>
+  <ItemGroup>
+    <PixelShader Include="AdvancedGraphics\Direct3D\Shaders\PostProcessingColor.hlsl"/>
+    <VertexShader Include="AdvancedGraphics\Direct3D\Shaders\PostProcessingQuad.hlsl"/>
+    <None Include="AdvancedGraphics\Direct3D\Shaders\ColorSpace.hlsl"/>
+    <None Include="AdvancedGraphics\Direct3D\Shaders\ShaderInputStructure.hlsl"/>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(IntermediateOutputPath)\AdvancedGraphics\Direct3D\Shaders\PostProcessingColor.cso">
+      <LogicalName>D3D11Shaders.PostProcessingColor.cso</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(IntermediateOutputPath)\AdvancedGraphics\Direct3D\Shaders\PostProcessingQuad.cso">
+      <LogicalName>D3D11Shaders.PostProcessingQuad.cso</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/ShareX/CaptureHelpers/CaptureRegion.cs
+++ b/ShareX/CaptureHelpers/CaptureRegion.cs
@@ -75,6 +75,7 @@ namespace ShareX
             Bitmap canvas;
             Screenshot screenshot = TaskHelpers.GetScreenshot(taskSettings);
             screenshot.CaptureCursor = false;
+            screenshot.UseWinRTCaptureAPI = taskSettings.CaptureSettings.UseWinRTGraphicsCaptureAPI;
 
             if (taskSettings.CaptureSettings.SurfaceOptions.ActiveMonitorMode)
             {

--- a/ShareX/Forms/TaskSettingsForm.Designer.cs
+++ b/ShareX/Forms/TaskSettingsForm.Designer.cs
@@ -139,6 +139,7 @@
             this.tcCapture = new System.Windows.Forms.TabControl();
             this.tpCaptureGeneral = new System.Windows.Forms.TabPage();
             this.pCapture = new System.Windows.Forms.Panel();
+            this.cbUseWinRTCapture = new System.Windows.Forms.CheckBox();
             this.txtCaptureCustomWindow = new System.Windows.Forms.TextBox();
             this.lblCaptureCustomWindow = new System.Windows.Forms.Label();
             this.lblScreenshotDelay = new System.Windows.Forms.Label();
@@ -261,8 +262,8 @@
             this.cbClipboardUploadShortenURL = new System.Windows.Forms.CheckBox();
             this.tpUploaderFilters = new System.Windows.Forms.TabPage();
             this.lvUploaderFiltersList = new ShareX.HelpersLib.MyListView();
-            this.chUploaderFiltersName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chUploaderFiltersExtension = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chUploaderFiltersName = new System.Windows.Forms.ColumnHeader();
+            this.chUploaderFiltersExtension = new System.Windows.Forms.ColumnHeader();
             this.btnUploaderFiltersRemove = new System.Windows.Forms.Button();
             this.btnUploaderFiltersUpdate = new System.Windows.Forms.Button();
             this.btnUploaderFiltersAdd = new System.Windows.Forms.Button();
@@ -278,10 +279,10 @@
             this.btnActionsDuplicate = new System.Windows.Forms.Button();
             this.btnActionsAdd = new System.Windows.Forms.Button();
             this.lvActions = new ShareX.HelpersLib.MyListView();
-            this.chActionsName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chActionsPath = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chActionsArgs = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chActionsExtensions = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chActionsName = new System.Windows.Forms.ColumnHeader();
+            this.chActionsPath = new System.Windows.Forms.ColumnHeader();
+            this.chActionsArgs = new System.Windows.Forms.ColumnHeader();
+            this.chActionsExtensions = new System.Windows.Forms.ColumnHeader();
             this.btnActionsEdit = new System.Windows.Forms.Button();
             this.btnActionsRemove = new System.Windows.Forms.Button();
             this.cbOverrideActions = new System.Windows.Forms.CheckBox();
@@ -289,9 +290,9 @@
             this.btnWatchFolderEdit = new System.Windows.Forms.Button();
             this.cbWatchFolderEnabled = new System.Windows.Forms.CheckBox();
             this.lvWatchFolderList = new ShareX.HelpersLib.MyListView();
-            this.chWatchFolderFolderPath = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chWatchFolderFilter = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.chWatchFolderIncludeSubdirectories = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.chWatchFolderFolderPath = new System.Windows.Forms.ColumnHeader();
+            this.chWatchFolderFilter = new System.Windows.Forms.ColumnHeader();
+            this.chWatchFolderIncludeSubdirectories = new System.Windows.Forms.ColumnHeader();
             this.btnWatchFolderRemove = new System.Windows.Forms.Button();
             this.btnWatchFolderAdd = new System.Windows.Forms.Button();
             this.tpTools = new System.Windows.Forms.TabPage();
@@ -537,12 +538,7 @@
             // 
             // cmsDestinations
             // 
-            this.cmsDestinations.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.tsmiImageUploaders,
-            this.tsmiTextUploaders,
-            this.tsmiFileUploaders,
-            this.tsmiURLShorteners,
-            this.tsmiURLSharingServices});
+            this.cmsDestinations.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { this.tsmiImageUploaders, this.tsmiTextUploaders, this.tsmiFileUploaders, this.tsmiURLShorteners, this.tsmiURLSharingServices });
             this.cmsDestinations.Name = "cmsDestinations";
             resources.ApplyResources(this.cmsDestinations, "cmsDestinations");
             // 
@@ -808,43 +804,19 @@
             // nudToastWindowSizeHeight
             // 
             resources.ApplyResources(this.nudToastWindowSizeHeight, "nudToastWindowSizeHeight");
-            this.nudToastWindowSizeHeight.Maximum = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            this.nudToastWindowSizeHeight.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            0});
+            this.nudToastWindowSizeHeight.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
+            this.nudToastWindowSizeHeight.Minimum = new decimal(new int[] { 100, 0, 0, 0 });
             this.nudToastWindowSizeHeight.Name = "nudToastWindowSizeHeight";
-            this.nudToastWindowSizeHeight.Value = new decimal(new int[] {
-            100,
-            0,
-            0,
-            0});
+            this.nudToastWindowSizeHeight.Value = new decimal(new int[] { 100, 0, 0, 0 });
             this.nudToastWindowSizeHeight.ValueChanged += new System.EventHandler(this.nudToastWindowSizeHeight_ValueChanged);
             // 
             // nudToastWindowSizeWidth
             // 
             resources.ApplyResources(this.nudToastWindowSizeWidth, "nudToastWindowSizeWidth");
-            this.nudToastWindowSizeWidth.Maximum = new decimal(new int[] {
-            1000,
-            0,
-            0,
-            0});
-            this.nudToastWindowSizeWidth.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            0});
+            this.nudToastWindowSizeWidth.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
+            this.nudToastWindowSizeWidth.Minimum = new decimal(new int[] { 100, 0, 0, 0 });
             this.nudToastWindowSizeWidth.Name = "nudToastWindowSizeWidth";
-            this.nudToastWindowSizeWidth.Value = new decimal(new int[] {
-            100,
-            0,
-            0,
-            0});
+            this.nudToastWindowSizeWidth.Value = new decimal(new int[] { 100, 0, 0, 0 });
             this.nudToastWindowSizeWidth.ValueChanged += new System.EventHandler(this.nudToastWindowSizeWidth_ValueChanged);
             // 
             // cbToastWindowPlacement
@@ -859,11 +831,7 @@
             // 
             this.nudToastWindowFadeDuration.DecimalPlaces = 1;
             resources.ApplyResources(this.nudToastWindowFadeDuration, "nudToastWindowFadeDuration");
-            this.nudToastWindowFadeDuration.Maximum = new decimal(new int[] {
-            30,
-            0,
-            0,
-            0});
+            this.nudToastWindowFadeDuration.Maximum = new decimal(new int[] { 30, 0, 0, 0 });
             this.nudToastWindowFadeDuration.Name = "nudToastWindowFadeDuration";
             this.nudToastWindowFadeDuration.ValueChanged += new System.EventHandler(this.nudToastWindowFadeDuration_ValueChanged);
             // 
@@ -878,11 +846,7 @@
             // 
             this.nudToastWindowDuration.DecimalPlaces = 1;
             resources.ApplyResources(this.nudToastWindowDuration, "nudToastWindowDuration");
-            this.nudToastWindowDuration.Maximum = new decimal(new int[] {
-            30,
-            0,
-            0,
-            0});
+            this.nudToastWindowDuration.Maximum = new decimal(new int[] { 30, 0, 0, 0 });
             this.nudToastWindowDuration.Name = "nudToastWindowDuration";
             this.nudToastWindowDuration.ValueChanged += new System.EventHandler(this.nudToastWindowDuration_ValueChanged);
             // 
@@ -1027,22 +991,10 @@
             // nudImageAutoUseJPEGSize
             // 
             resources.ApplyResources(this.nudImageAutoUseJPEGSize, "nudImageAutoUseJPEGSize");
-            this.nudImageAutoUseJPEGSize.Maximum = new decimal(new int[] {
-            100000,
-            0,
-            0,
-            0});
-            this.nudImageAutoUseJPEGSize.Minimum = new decimal(new int[] {
-            100,
-            0,
-            0,
-            0});
+            this.nudImageAutoUseJPEGSize.Maximum = new decimal(new int[] { 100000, 0, 0, 0 });
+            this.nudImageAutoUseJPEGSize.Minimum = new decimal(new int[] { 100, 0, 0, 0 });
             this.nudImageAutoUseJPEGSize.Name = "nudImageAutoUseJPEGSize";
-            this.nudImageAutoUseJPEGSize.Value = new decimal(new int[] {
-            2048,
-            0,
-            0,
-            0});
+            this.nudImageAutoUseJPEGSize.Value = new decimal(new int[] { 2048, 0, 0, 0 });
             this.nudImageAutoUseJPEGSize.ValueChanged += new System.EventHandler(this.nudImageAutoUseJPEGSize_ValueChanged);
             // 
             // lblImageSizeLimitHint
@@ -1054,11 +1006,7 @@
             // 
             resources.ApplyResources(this.nudImageJPEGQuality, "nudImageJPEGQuality");
             this.nudImageJPEGQuality.Name = "nudImageJPEGQuality";
-            this.nudImageJPEGQuality.Value = new decimal(new int[] {
-            90,
-            0,
-            0,
-            0});
+            this.nudImageJPEGQuality.Value = new decimal(new int[] { 90, 0, 0, 0 });
             this.nudImageJPEGQuality.ValueChanged += new System.EventHandler(this.nudImageJPEGQuality_ValueChanged);
             // 
             // cbImageFormat
@@ -1195,22 +1143,14 @@
             // nudThumbnailHeight
             // 
             resources.ApplyResources(this.nudThumbnailHeight, "nudThumbnailHeight");
-            this.nudThumbnailHeight.Maximum = new decimal(new int[] {
-            2000,
-            0,
-            0,
-            0});
+            this.nudThumbnailHeight.Maximum = new decimal(new int[] { 2000, 0, 0, 0 });
             this.nudThumbnailHeight.Name = "nudThumbnailHeight";
             this.nudThumbnailHeight.ValueChanged += new System.EventHandler(this.nudThumbnailHeight_ValueChanged);
             // 
             // nudThumbnailWidth
             // 
             resources.ApplyResources(this.nudThumbnailWidth, "nudThumbnailWidth");
-            this.nudThumbnailWidth.Maximum = new decimal(new int[] {
-            2000,
-            0,
-            0,
-            0});
+            this.nudThumbnailWidth.Maximum = new decimal(new int[] { 2000, 0, 0, 0 });
             this.nudThumbnailWidth.Name = "nudThumbnailWidth";
             this.nudThumbnailWidth.ValueChanged += new System.EventHandler(this.nudThumbnailWidth_ValueChanged);
             // 
@@ -1241,6 +1181,7 @@
             // 
             // pCapture
             // 
+            this.pCapture.Controls.Add(this.cbUseWinRTCapture);
             this.pCapture.Controls.Add(this.txtCaptureCustomWindow);
             this.pCapture.Controls.Add(this.lblCaptureCustomWindow);
             this.pCapture.Controls.Add(this.lblScreenshotDelay);
@@ -1265,6 +1206,13 @@
             this.pCapture.Controls.Add(this.nudCaptureShadowOffset);
             resources.ApplyResources(this.pCapture, "pCapture");
             this.pCapture.Name = "pCapture";
+            // 
+            // cbUseWinRTCapture
+            // 
+            resources.ApplyResources(this.cbUseWinRTCapture, "cbUseWinRTCapture");
+            this.cbUseWinRTCapture.Name = "cbUseWinRTCapture";
+            this.cbUseWinRTCapture.UseVisualStyleBackColor = true;
+            this.cbUseWinRTCapture.CheckedChanged += new System.EventHandler(this.cbUseWinRTCapture_CheckedChanged);
             // 
             // txtCaptureCustomWindow
             // 
@@ -1317,64 +1265,32 @@
             // nudCaptureCustomRegionHeight
             // 
             resources.ApplyResources(this.nudCaptureCustomRegionHeight, "nudCaptureCustomRegionHeight");
-            this.nudCaptureCustomRegionHeight.Maximum = new decimal(new int[] {
-            -2147483648,
-            0,
-            0,
-            0});
-            this.nudCaptureCustomRegionHeight.Minimum = new decimal(new int[] {
-            -2147483648,
-            0,
-            0,
-            -2147483648});
+            this.nudCaptureCustomRegionHeight.Maximum = new decimal(new int[] { -2147483648, 0, 0, 0 });
+            this.nudCaptureCustomRegionHeight.Minimum = new decimal(new int[] { -2147483648, 0, 0, -2147483648 });
             this.nudCaptureCustomRegionHeight.Name = "nudCaptureCustomRegionHeight";
             this.nudCaptureCustomRegionHeight.ValueChanged += new System.EventHandler(this.nudScreenRegionHeight_ValueChanged);
             // 
             // nudCaptureCustomRegionWidth
             // 
             resources.ApplyResources(this.nudCaptureCustomRegionWidth, "nudCaptureCustomRegionWidth");
-            this.nudCaptureCustomRegionWidth.Maximum = new decimal(new int[] {
-            -2147483648,
-            0,
-            0,
-            0});
-            this.nudCaptureCustomRegionWidth.Minimum = new decimal(new int[] {
-            -2147483648,
-            0,
-            0,
-            -2147483648});
+            this.nudCaptureCustomRegionWidth.Maximum = new decimal(new int[] { -2147483648, 0, 0, 0 });
+            this.nudCaptureCustomRegionWidth.Minimum = new decimal(new int[] { -2147483648, 0, 0, -2147483648 });
             this.nudCaptureCustomRegionWidth.Name = "nudCaptureCustomRegionWidth";
             this.nudCaptureCustomRegionWidth.ValueChanged += new System.EventHandler(this.nudScreenRegionWidth_ValueChanged);
             // 
             // nudCaptureCustomRegionY
             // 
             resources.ApplyResources(this.nudCaptureCustomRegionY, "nudCaptureCustomRegionY");
-            this.nudCaptureCustomRegionY.Maximum = new decimal(new int[] {
-            -2147483648,
-            0,
-            0,
-            0});
-            this.nudCaptureCustomRegionY.Minimum = new decimal(new int[] {
-            -2147483648,
-            0,
-            0,
-            -2147483648});
+            this.nudCaptureCustomRegionY.Maximum = new decimal(new int[] { -2147483648, 0, 0, 0 });
+            this.nudCaptureCustomRegionY.Minimum = new decimal(new int[] { -2147483648, 0, 0, -2147483648 });
             this.nudCaptureCustomRegionY.Name = "nudCaptureCustomRegionY";
             this.nudCaptureCustomRegionY.ValueChanged += new System.EventHandler(this.nudScreenRegionY_ValueChanged);
             // 
             // nudCaptureCustomRegionX
             // 
             resources.ApplyResources(this.nudCaptureCustomRegionX, "nudCaptureCustomRegionX");
-            this.nudCaptureCustomRegionX.Maximum = new decimal(new int[] {
-            -2147483648,
-            0,
-            0,
-            0});
-            this.nudCaptureCustomRegionX.Minimum = new decimal(new int[] {
-            -2147483648,
-            0,
-            0,
-            -2147483648});
+            this.nudCaptureCustomRegionX.Maximum = new decimal(new int[] { -2147483648, 0, 0, 0 });
+            this.nudCaptureCustomRegionX.Minimum = new decimal(new int[] { -2147483648, 0, 0, -2147483648 });
             this.nudCaptureCustomRegionX.Name = "nudCaptureCustomRegionX";
             this.nudCaptureCustomRegionX.ValueChanged += new System.EventHandler(this.nudScreenRegionX_ValueChanged);
             // 
@@ -1427,28 +1343,16 @@
             // 
             this.nudScreenshotDelay.DecimalPlaces = 1;
             resources.ApplyResources(this.nudScreenshotDelay, "nudScreenshotDelay");
-            this.nudScreenshotDelay.Maximum = new decimal(new int[] {
-            300,
-            0,
-            0,
-            0});
+            this.nudScreenshotDelay.Maximum = new decimal(new int[] { 300, 0, 0, 0 });
             this.nudScreenshotDelay.Name = "nudScreenshotDelay";
             this.nudScreenshotDelay.ValueChanged += new System.EventHandler(this.nudScreenshotDelay_ValueChanged);
             // 
             // nudCaptureShadowOffset
             // 
             resources.ApplyResources(this.nudCaptureShadowOffset, "nudCaptureShadowOffset");
-            this.nudCaptureShadowOffset.Maximum = new decimal(new int[] {
-            200,
-            0,
-            0,
-            0});
+            this.nudCaptureShadowOffset.Maximum = new decimal(new int[] { 200, 0, 0, 0 });
             this.nudCaptureShadowOffset.Name = "nudCaptureShadowOffset";
-            this.nudCaptureShadowOffset.Value = new decimal(new int[] {
-            100,
-            0,
-            0,
-            0});
+            this.nudCaptureShadowOffset.Value = new decimal(new int[] { 100, 0, 0, 0 });
             this.nudCaptureShadowOffset.ValueChanged += new System.EventHandler(this.nudCaptureShadowOffset_ValueChanged);
             // 
             // cbOverrideCaptureSettings
@@ -1509,11 +1413,7 @@
             // nudRegionCaptureBackgroundDimStrength
             // 
             resources.ApplyResources(this.nudRegionCaptureBackgroundDimStrength, "nudRegionCaptureBackgroundDimStrength");
-            this.nudRegionCaptureBackgroundDimStrength.Maximum = new decimal(new int[] {
-            50,
-            0,
-            0,
-            0});
+            this.nudRegionCaptureBackgroundDimStrength.Maximum = new decimal(new int[] { 50, 0, 0, 0 });
             this.nudRegionCaptureBackgroundDimStrength.Name = "nudRegionCaptureBackgroundDimStrength";
             this.nudRegionCaptureBackgroundDimStrength.ValueChanged += new System.EventHandler(this.nudRegionCaptureBackgroundDimStrength_ValueChanged);
             // 
@@ -1532,11 +1432,7 @@
             // nudRegionCaptureFPSLimit
             // 
             resources.ApplyResources(this.nudRegionCaptureFPSLimit, "nudRegionCaptureFPSLimit");
-            this.nudRegionCaptureFPSLimit.Maximum = new decimal(new int[] {
-            300,
-            0,
-            0,
-            0});
+            this.nudRegionCaptureFPSLimit.Maximum = new decimal(new int[] { 300, 0, 0, 0 });
             this.nudRegionCaptureFPSLimit.Name = "nudRegionCaptureFPSLimit";
             this.nudRegionCaptureFPSLimit.ValueChanged += new System.EventHandler(this.nudRegionCaptureFPSLimit_ValueChanged);
             // 
@@ -1568,28 +1464,12 @@
             // 
             // nudRegionCaptureFixedSizeWidth
             // 
-            this.nudRegionCaptureFixedSizeWidth.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
+            this.nudRegionCaptureFixedSizeWidth.Increment = new decimal(new int[] { 10, 0, 0, 0 });
             resources.ApplyResources(this.nudRegionCaptureFixedSizeWidth, "nudRegionCaptureFixedSizeWidth");
-            this.nudRegionCaptureFixedSizeWidth.Maximum = new decimal(new int[] {
-            10000,
-            0,
-            0,
-            0});
-            this.nudRegionCaptureFixedSizeWidth.Minimum = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
+            this.nudRegionCaptureFixedSizeWidth.Maximum = new decimal(new int[] { 10000, 0, 0, 0 });
+            this.nudRegionCaptureFixedSizeWidth.Minimum = new decimal(new int[] { 10, 0, 0, 0 });
             this.nudRegionCaptureFixedSizeWidth.Name = "nudRegionCaptureFixedSizeWidth";
-            this.nudRegionCaptureFixedSizeWidth.Value = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
+            this.nudRegionCaptureFixedSizeWidth.Value = new decimal(new int[] { 10, 0, 0, 0 });
             this.nudRegionCaptureFixedSizeWidth.ValueChanged += new System.EventHandler(this.nudRegionCaptureFixedSizeWidth_ValueChanged);
             // 
             // lblRegionCaptureFixedSizeHeight
@@ -1599,28 +1479,12 @@
             // 
             // nudRegionCaptureFixedSizeHeight
             // 
-            this.nudRegionCaptureFixedSizeHeight.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
+            this.nudRegionCaptureFixedSizeHeight.Increment = new decimal(new int[] { 10, 0, 0, 0 });
             resources.ApplyResources(this.nudRegionCaptureFixedSizeHeight, "nudRegionCaptureFixedSizeHeight");
-            this.nudRegionCaptureFixedSizeHeight.Maximum = new decimal(new int[] {
-            10000,
-            0,
-            0,
-            0});
-            this.nudRegionCaptureFixedSizeHeight.Minimum = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
+            this.nudRegionCaptureFixedSizeHeight.Maximum = new decimal(new int[] { 10000, 0, 0, 0 });
+            this.nudRegionCaptureFixedSizeHeight.Minimum = new decimal(new int[] { 10, 0, 0, 0 });
             this.nudRegionCaptureFixedSizeHeight.Name = "nudRegionCaptureFixedSizeHeight";
-            this.nudRegionCaptureFixedSizeHeight.Value = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
+            this.nudRegionCaptureFixedSizeHeight.Value = new decimal(new int[] { 10, 0, 0, 0 });
             this.nudRegionCaptureFixedSizeHeight.ValueChanged += new System.EventHandler(this.nudRegionCaptureFixedSizeHeight_ValueChanged);
             // 
             // cbRegionCaptureIsFixedSize
@@ -1803,22 +1667,10 @@
             // nudRegionCaptureSnapSizesHeight
             // 
             resources.ApplyResources(this.nudRegionCaptureSnapSizesHeight, "nudRegionCaptureSnapSizesHeight");
-            this.nudRegionCaptureSnapSizesHeight.Maximum = new decimal(new int[] {
-            10000,
-            0,
-            0,
-            0});
-            this.nudRegionCaptureSnapSizesHeight.Minimum = new decimal(new int[] {
-            2,
-            0,
-            0,
-            0});
+            this.nudRegionCaptureSnapSizesHeight.Maximum = new decimal(new int[] { 10000, 0, 0, 0 });
+            this.nudRegionCaptureSnapSizesHeight.Minimum = new decimal(new int[] { 2, 0, 0, 0 });
             this.nudRegionCaptureSnapSizesHeight.Name = "nudRegionCaptureSnapSizesHeight";
-            this.nudRegionCaptureSnapSizesHeight.Value = new decimal(new int[] {
-            100,
-            0,
-            0,
-            0});
+            this.nudRegionCaptureSnapSizesHeight.Value = new decimal(new int[] { 100, 0, 0, 0 });
             // 
             // RegionCaptureSnapSizesHeight
             // 
@@ -1828,22 +1680,10 @@
             // nudRegionCaptureSnapSizesWidth
             // 
             resources.ApplyResources(this.nudRegionCaptureSnapSizesWidth, "nudRegionCaptureSnapSizesWidth");
-            this.nudRegionCaptureSnapSizesWidth.Maximum = new decimal(new int[] {
-            10000,
-            0,
-            0,
-            0});
-            this.nudRegionCaptureSnapSizesWidth.Minimum = new decimal(new int[] {
-            2,
-            0,
-            0,
-            0});
+            this.nudRegionCaptureSnapSizesWidth.Maximum = new decimal(new int[] { 10000, 0, 0, 0 });
+            this.nudRegionCaptureSnapSizesWidth.Minimum = new decimal(new int[] { 2, 0, 0, 0 });
             this.nudRegionCaptureSnapSizesWidth.Name = "nudRegionCaptureSnapSizesWidth";
-            this.nudRegionCaptureSnapSizesWidth.Value = new decimal(new int[] {
-            100,
-            0,
-            0,
-            0});
+            this.nudRegionCaptureSnapSizesWidth.Value = new decimal(new int[] { 100, 0, 0, 0 });
             // 
             // lblRegionCaptureSnapSizesWidth
             // 
@@ -1858,11 +1698,7 @@
             // 
             // nudRegionCaptureMagnifierPixelCount
             // 
-            this.nudRegionCaptureMagnifierPixelCount.Increment = new decimal(new int[] {
-            2,
-            0,
-            0,
-            0});
+            this.nudRegionCaptureMagnifierPixelCount.Increment = new decimal(new int[] { 2, 0, 0, 0 });
             resources.ApplyResources(this.nudRegionCaptureMagnifierPixelCount, "nudRegionCaptureMagnifierPixelCount");
             this.nudRegionCaptureMagnifierPixelCount.Name = "nudRegionCaptureMagnifierPixelCount";
             this.nudRegionCaptureMagnifierPixelCount.ValueChanged += new System.EventHandler(this.nudRegionCaptureMagnifierPixelCount_ValueChanged);
@@ -1949,22 +1785,10 @@
             // nudScreenRecordFPS
             // 
             resources.ApplyResources(this.nudScreenRecordFPS, "nudScreenRecordFPS");
-            this.nudScreenRecordFPS.Maximum = new decimal(new int[] {
-            60,
-            0,
-            0,
-            0});
-            this.nudScreenRecordFPS.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+            this.nudScreenRecordFPS.Maximum = new decimal(new int[] { 60, 0, 0, 0 });
+            this.nudScreenRecordFPS.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
             this.nudScreenRecordFPS.Name = "nudScreenRecordFPS";
-            this.nudScreenRecordFPS.Value = new decimal(new int[] {
-            20,
-            0,
-            0,
-            0});
+            this.nudScreenRecordFPS.Value = new decimal(new int[] { 20, 0, 0, 0 });
             this.nudScreenRecordFPS.ValueChanged += new System.EventHandler(this.nudScreenRecordFPS_ValueChanged);
             // 
             // lblScreenRecordFPS
@@ -1975,50 +1799,22 @@
             // nudScreenRecorderDuration
             // 
             this.nudScreenRecorderDuration.DecimalPlaces = 1;
-            this.nudScreenRecorderDuration.Increment = new decimal(new int[] {
-            5,
-            0,
-            0,
-            65536});
+            this.nudScreenRecorderDuration.Increment = new decimal(new int[] { 5, 0, 0, 65536 });
             resources.ApplyResources(this.nudScreenRecorderDuration, "nudScreenRecorderDuration");
-            this.nudScreenRecorderDuration.Maximum = new decimal(new int[] {
-            60,
-            0,
-            0,
-            0});
-            this.nudScreenRecorderDuration.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+            this.nudScreenRecorderDuration.Maximum = new decimal(new int[] { 60, 0, 0, 0 });
+            this.nudScreenRecorderDuration.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
             this.nudScreenRecorderDuration.Name = "nudScreenRecorderDuration";
-            this.nudScreenRecorderDuration.Value = new decimal(new int[] {
-            3,
-            0,
-            0,
-            0});
+            this.nudScreenRecorderDuration.Value = new decimal(new int[] { 3, 0, 0, 0 });
             this.nudScreenRecorderDuration.ValueChanged += new System.EventHandler(this.nudScreenRecorderDuration_ValueChanged);
             // 
             // nudScreenRecorderStartDelay
             // 
             this.nudScreenRecorderStartDelay.DecimalPlaces = 1;
-            this.nudScreenRecorderStartDelay.Increment = new decimal(new int[] {
-            5,
-            0,
-            0,
-            65536});
+            this.nudScreenRecorderStartDelay.Increment = new decimal(new int[] { 5, 0, 0, 65536 });
             resources.ApplyResources(this.nudScreenRecorderStartDelay, "nudScreenRecorderStartDelay");
-            this.nudScreenRecorderStartDelay.Maximum = new decimal(new int[] {
-            60,
-            0,
-            0,
-            0});
+            this.nudScreenRecorderStartDelay.Maximum = new decimal(new int[] { 60, 0, 0, 0 });
             this.nudScreenRecorderStartDelay.Name = "nudScreenRecorderStartDelay";
-            this.nudScreenRecorderStartDelay.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+            this.nudScreenRecorderStartDelay.Value = new decimal(new int[] { 1, 0, 0, 0 });
             this.nudScreenRecorderStartDelay.ValueChanged += new System.EventHandler(this.nudScreenRecorderStartDelay_ValueChanged);
             // 
             // cbScreenRecorderFixedDuration
@@ -2031,22 +1827,10 @@
             // nudGIFFPS
             // 
             resources.ApplyResources(this.nudGIFFPS, "nudGIFFPS");
-            this.nudGIFFPS.Maximum = new decimal(new int[] {
-            30,
-            0,
-            0,
-            0});
-            this.nudGIFFPS.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+            this.nudGIFFPS.Maximum = new decimal(new int[] { 30, 0, 0, 0 });
+            this.nudGIFFPS.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
             this.nudGIFFPS.Name = "nudGIFFPS";
-            this.nudGIFFPS.Value = new decimal(new int[] {
-            5,
-            0,
-            0,
-            0});
+            this.nudGIFFPS.Value = new decimal(new int[] { 5, 0, 0, 0 });
             this.nudGIFFPS.ValueChanged += new System.EventHandler(this.nudGIFFPS_ValueChanged);
             // 
             // lblGIFFPS
@@ -2209,11 +1993,7 @@
             // nudAutoIncrementNumber
             // 
             resources.ApplyResources(this.nudAutoIncrementNumber, "nudAutoIncrementNumber");
-            this.nudAutoIncrementNumber.Maximum = new decimal(new int[] {
-            1000000000,
-            0,
-            0,
-            0});
+            this.nudAutoIncrementNumber.Maximum = new decimal(new int[] { 1000000000, 0, 0, 0 });
             this.nudAutoIncrementNumber.Name = "nudAutoIncrementNumber";
             // 
             // cbFileUploadReplaceProblematicCharacters
@@ -2334,9 +2114,7 @@
             // 
             resources.ApplyResources(this.lvUploaderFiltersList, "lvUploaderFiltersList");
             this.lvUploaderFiltersList.AutoFillColumn = true;
-            this.lvUploaderFiltersList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.chUploaderFiltersName,
-            this.chUploaderFiltersExtension});
+            this.lvUploaderFiltersList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] { this.chUploaderFiltersName, this.chUploaderFiltersExtension });
             this.lvUploaderFiltersList.FullRowSelect = true;
             this.lvUploaderFiltersList.HideSelection = false;
             this.lvUploaderFiltersList.Name = "lvUploaderFiltersList";
@@ -2454,11 +2232,7 @@
             this.lvActions.AutoFillColumn = true;
             this.lvActions.AutoFillColumnIndex = 2;
             this.lvActions.CheckBoxes = true;
-            this.lvActions.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.chActionsName,
-            this.chActionsPath,
-            this.chActionsArgs,
-            this.chActionsExtensions});
+            this.lvActions.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] { this.chActionsName, this.chActionsPath, this.chActionsArgs, this.chActionsExtensions });
             this.lvActions.FullRowSelect = true;
             this.lvActions.HideSelection = false;
             this.lvActions.MultiSelect = false;
@@ -2537,10 +2311,7 @@
             // 
             resources.ApplyResources(this.lvWatchFolderList, "lvWatchFolderList");
             this.lvWatchFolderList.AutoFillColumn = true;
-            this.lvWatchFolderList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.chWatchFolderFolderPath,
-            this.chWatchFolderFilter,
-            this.chWatchFolderIncludeSubdirectories});
+            this.lvWatchFolderList.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] { this.chWatchFolderFolderPath, this.chWatchFolderFilter, this.chWatchFolderIncludeSubdirectories });
             this.lvWatchFolderList.FullRowSelect = true;
             this.lvWatchFolderList.HideSelection = false;
             this.lvWatchFolderList.Name = "lvWatchFolderList";
@@ -2769,7 +2540,6 @@
             this.tpAdvanced.ResumeLayout(false);
             this.tpAdvanced.PerformLayout();
             this.ResumeLayout(false);
-
         }
 
         #endregion
@@ -3051,5 +2821,6 @@
         private System.Windows.Forms.Button btnCustomActionCompletedSoundPath;
         private System.Windows.Forms.TextBox txtCustomActionCompletedSoundPath;
         private System.Windows.Forms.CheckBox cbUseCustomActionCompletedSound;
+        private System.Windows.Forms.CheckBox cbUseWinRTCapture;
     }
 }

--- a/ShareX/Forms/TaskSettingsForm.cs
+++ b/ShareX/Forms/TaskSettingsForm.cs
@@ -26,6 +26,7 @@
 using ShareX.HelpersLib;
 using ShareX.Properties;
 using ShareX.ScreenCaptureLib;
+using ShareX.ScreenCaptureLib.AdvancedGraphics.Direct3D;
 using ShareX.UploadersLib;
 using System;
 using System.Collections.Generic;
@@ -272,6 +273,8 @@ namespace ShareX
             #region General
 
             cbShowCursor.Checked = TaskSettings.CaptureSettings.ShowCursor;
+            cbUseWinRTCapture.Checked = TaskSettings.CaptureSettings.UseWinRTGraphicsCaptureAPI;
+            cbUseWinRTCapture.Enabled = ModernCaptureSignletonManager.Instance.IsAvailable;
             nudScreenshotDelay.SetValue(TaskSettings.CaptureSettings.ScreenshotDelay);
             cbCaptureTransparent.Checked = TaskSettings.CaptureSettings.CaptureTransparent;
             cbCaptureShadow.Enabled = TaskSettings.CaptureSettings.CaptureTransparent;
@@ -1063,6 +1066,11 @@ namespace ShareX
         private void cbShowCursor_CheckedChanged(object sender, EventArgs e)
         {
             TaskSettings.CaptureSettings.ShowCursor = cbShowCursor.Checked;
+        }
+
+        private void cbUseWinRTCapture_CheckedChanged(object sender, EventArgs e)
+        {
+            TaskSettings.CaptureSettings.UseWinRTGraphicsCaptureAPI = cbUseWinRTCapture.Checked;
         }
 
         private void nudScreenshotDelay_ValueChanged(object sender, EventArgs e)

--- a/ShareX/Forms/TaskSettingsForm.resx
+++ b/ShareX/Forms/TaskSettingsForm.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -151,10 +151,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbOverrideAfterCaptureSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 96</value>
+    <value>10, 120</value>
+  </data>
+  <data name="cbOverrideAfterCaptureSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbOverrideAfterCaptureSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>157, 17</value>
+    <value>207, 21</value>
   </data>
   <data name="cbOverrideAfterCaptureSettings.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -181,10 +184,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbOverrideAfterUploadSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 152</value>
+    <value>10, 190</value>
+  </data>
+  <data name="cbOverrideAfterUploadSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbOverrideAfterUploadSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>153, 17</value>
+    <value>202, 21</value>
   </data>
   <data name="cbOverrideAfterUploadSettings.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -211,10 +217,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbOverrideDestinationSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 208</value>
+    <value>10, 260</value>
+  </data>
+  <data name="cbOverrideDestinationSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbOverrideDestinationSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>125, 17</value>
+    <value>165, 21</value>
   </data>
   <data name="cbOverrideDestinationSettings.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -241,10 +250,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 53</value>
+    <value>6, 66</value>
+  </data>
+  <data name="lblDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 13</value>
+    <value>83, 17</value>
   </data>
   <data name="lblDescription.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -265,10 +277,13 @@
     <value>16</value>
   </data>
   <data name="tbDescription.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 69</value>
+    <value>10, 86</value>
+  </data>
+  <data name="tbDescription.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tbDescription.Size" type="System.Drawing.Size, System.Drawing">
-    <value>552, 20</value>
+    <value>689, 22</value>
   </data>
   <data name="tbDescription.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -301,10 +316,13 @@
     <value>True</value>
   </data>
   <data name="lblTask.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 8</value>
+    <value>6, 10</value>
+  </data>
+  <data name="lblTask.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblTask.Size" type="System.Drawing.Size, System.Drawing">
-    <value>34, 13</value>
+    <value>43, 17</value>
   </data>
   <data name="lblTask.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -328,10 +346,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnScreenshotsFolderBrowse.Location" type="System.Drawing.Point, System.Drawing">
-    <value>464, 399</value>
+    <value>580, 499</value>
+  </data>
+  <data name="btnScreenshotsFolderBrowse.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnScreenshotsFolderBrowse.Size" type="System.Drawing.Size, System.Drawing">
-    <value>96, 23</value>
+    <value>120, 29</value>
   </data>
   <data name="btnScreenshotsFolderBrowse.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -352,10 +373,13 @@
     <value>1</value>
   </data>
   <data name="txtScreenshotsFolder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 400</value>
+    <value>10, 500</value>
+  </data>
+  <data name="txtScreenshotsFolder.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtScreenshotsFolder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>448, 20</value>
+    <value>559, 22</value>
   </data>
   <data name="txtScreenshotsFolder.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -379,10 +403,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbOverrideScreenshotsFolder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 376</value>
+    <value>10, 470</value>
+  </data>
+  <data name="cbOverrideScreenshotsFolder.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbOverrideScreenshotsFolder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>155, 17</value>
+    <value>206, 21</value>
   </data>
   <data name="cbOverrideScreenshotsFolder.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -403,10 +430,13 @@
     <value>3</value>
   </data>
   <data name="cbCustomUploaders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 344</value>
+    <value>10, 430</value>
+  </data>
+  <data name="cbCustomUploaders.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbCustomUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>552, 21</value>
+    <value>689, 24</value>
   </data>
   <data name="cbCustomUploaders.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -430,10 +460,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbOverrideCustomUploader.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 320</value>
+    <value>10, 400</value>
+  </data>
+  <data name="cbOverrideCustomUploader.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbOverrideCustomUploader.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 17</value>
+    <value>241, 21</value>
   </data>
   <data name="cbOverrideCustomUploader.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -460,10 +493,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbOverrideFTPAccount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 264</value>
+    <value>10, 330</value>
+  </data>
+  <data name="cbOverrideFTPAccount.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbOverrideFTPAccount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>166, 17</value>
+    <value>216, 21</value>
   </data>
   <data name="cbOverrideFTPAccount.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -484,10 +520,13 @@
     <value>6</value>
   </data>
   <data name="cbFTPAccounts.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 288</value>
+    <value>10, 360</value>
+  </data>
+  <data name="cbFTPAccounts.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbFTPAccounts.Size" type="System.Drawing.Size, System.Drawing">
-    <value>552, 21</value>
+    <value>689, 24</value>
   </data>
   <data name="cbFTPAccounts.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -508,10 +547,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnAfterCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 120</value>
+    <value>10, 150</value>
+  </data>
+  <data name="btnAfterCapture.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnAfterCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>552, 24</value>
+    <value>690, 30</value>
   </data>
   <data name="btnAfterCapture.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -538,10 +580,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnAfterUpload.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 176</value>
+    <value>10, 220</value>
+  </data>
+  <data name="btnAfterUpload.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnAfterUpload.Size" type="System.Drawing.Size, System.Drawing">
-    <value>552, 24</value>
+    <value>690, 30</value>
   </data>
   <data name="btnAfterUpload.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -568,43 +613,46 @@
     <value>NoControl</value>
   </data>
   <data name="btnDestinations.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 232</value>
+    <value>10, 290</value>
+  </data>
+  <data name="btnDestinations.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <metadata name="cmsDestinations.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>396, 17</value>
   </metadata>
   <data name="tsmiImageUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
+    <value>211, 24</value>
   </data>
   <data name="tsmiImageUploaders.Text" xml:space="preserve">
     <value>Image uploaders</value>
   </data>
   <data name="tsmiTextUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
+    <value>211, 24</value>
   </data>
   <data name="tsmiTextUploaders.Text" xml:space="preserve">
     <value>Text uploaders</value>
   </data>
   <data name="tsmiFileUploaders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
+    <value>211, 24</value>
   </data>
   <data name="tsmiFileUploaders.Text" xml:space="preserve">
     <value>File uploaders</value>
   </data>
   <data name="tsmiURLShorteners.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
+    <value>211, 24</value>
   </data>
   <data name="tsmiURLShorteners.Text" xml:space="preserve">
     <value>URL shorteners</value>
   </data>
   <data name="tsmiURLSharingServices.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 22</value>
+    <value>211, 24</value>
   </data>
   <data name="tsmiURLSharingServices.Text" xml:space="preserve">
     <value>URL sharing services</value>
   </data>
   <data name="cmsDestinations.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 114</value>
+    <value>212, 124</value>
   </data>
   <data name="&gt;&gt;cmsDestinations.Name" xml:space="preserve">
     <value>cmsDestinations</value>
@@ -613,7 +661,7 @@
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="btnDestinations.Size" type="System.Drawing.Size, System.Drawing">
-    <value>552, 24</value>
+    <value>690, 30</value>
   </data>
   <data name="btnDestinations.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -643,10 +691,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnTask.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 24</value>
+    <value>10, 30</value>
+  </data>
+  <data name="btnTask.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnTask.Size" type="System.Drawing.Size, System.Drawing">
-    <value>552, 24</value>
+    <value>690, 30</value>
   </data>
   <data name="btnTask.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -673,13 +724,16 @@
     <value>13</value>
   </data>
   <data name="tpTask.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpTask.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpTask.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpTask.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 485</value>
+    <value>716, 610</value>
   </data>
   <data name="tpTask.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -711,11 +765,14 @@
   <data name="cbOverrideGeneralSettings.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="cbOverrideGeneralSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
   <data name="cbOverrideGeneralSettings.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 0</value>
+    <value>10, 10, 10, 0</value>
   </data>
   <data name="cbOverrideGeneralSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 25</value>
+    <value>700, 31</value>
   </data>
   <data name="cbOverrideGeneralSettings.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -736,10 +793,13 @@
     <value>0</value>
   </data>
   <data name="tpGeneralMain.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpGeneralMain.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpGeneralMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 453</value>
+    <value>700, 573</value>
   </data>
   <data name="tpGeneralMain.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -760,10 +820,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnCustomActionCompletedSoundPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>536, 413</value>
+    <value>670, 516</value>
+  </data>
+  <data name="btnCustomActionCompletedSoundPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnCustomActionCompletedSoundPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>26, 23</value>
+    <value>32, 29</value>
   </data>
   <data name="btnCustomActionCompletedSoundPath.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -784,10 +847,13 @@
     <value>0</value>
   </data>
   <data name="txtCustomActionCompletedSoundPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>248, 414</value>
+    <value>310, 518</value>
+  </data>
+  <data name="txtCustomActionCompletedSoundPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtCustomActionCompletedSoundPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>280, 20</value>
+    <value>349, 22</value>
   </data>
   <data name="txtCustomActionCompletedSoundPath.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -811,10 +877,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbUseCustomActionCompletedSound.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 416</value>
+    <value>10, 520</value>
+  </data>
+  <data name="cbUseCustomActionCompletedSound.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbUseCustomActionCompletedSound.Size" type="System.Drawing.Size, System.Drawing">
-    <value>201, 17</value>
+    <value>262, 21</value>
   </data>
   <data name="cbUseCustomActionCompletedSound.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -838,10 +907,13 @@
     <value>True</value>
   </data>
   <data name="cbPlaySoundAfterAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 56</value>
+    <value>10, 70</value>
+  </data>
+  <data name="cbPlaySoundAfterAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbPlaySoundAfterAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>196, 17</value>
+    <value>258, 21</value>
   </data>
   <data name="cbPlaySoundAfterAction.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -868,10 +940,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbShowToastNotificationAfterTaskCompleted.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 80</value>
+    <value>10, 100</value>
+  </data>
+  <data name="cbShowToastNotificationAfterTaskCompleted.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbShowToastNotificationAfterTaskCompleted.Size" type="System.Drawing.Size, System.Drawing">
-    <value>242, 17</value>
+    <value>317, 21</value>
   </data>
   <data name="cbShowToastNotificationAfterTaskCompleted.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -895,10 +970,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnCustomErrorSoundPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>536, 437</value>
+    <value>670, 546</value>
+  </data>
+  <data name="btnCustomErrorSoundPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnCustomErrorSoundPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>26, 23</value>
+    <value>32, 29</value>
   </data>
   <data name="btnCustomErrorSoundPath.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -922,10 +1000,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnCustomTaskCompletedSoundPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>536, 389</value>
+    <value>670, 486</value>
+  </data>
+  <data name="btnCustomTaskCompletedSoundPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnCustomTaskCompletedSoundPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>26, 23</value>
+    <value>32, 29</value>
   </data>
   <data name="btnCustomTaskCompletedSoundPath.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -949,10 +1030,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnCustomCaptureSoundPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>536, 365</value>
+    <value>670, 456</value>
+  </data>
+  <data name="btnCustomCaptureSoundPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnCustomCaptureSoundPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>26, 23</value>
+    <value>32, 29</value>
   </data>
   <data name="btnCustomCaptureSoundPath.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -973,10 +1057,13 @@
     <value>7</value>
   </data>
   <data name="txtCustomErrorSoundPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>248, 438</value>
+    <value>310, 548</value>
+  </data>
+  <data name="txtCustomErrorSoundPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtCustomErrorSoundPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>280, 20</value>
+    <value>349, 22</value>
   </data>
   <data name="txtCustomErrorSoundPath.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -994,10 +1081,13 @@
     <value>8</value>
   </data>
   <data name="txtCustomTaskCompletedSoundPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>248, 390</value>
+    <value>310, 488</value>
+  </data>
+  <data name="txtCustomTaskCompletedSoundPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtCustomTaskCompletedSoundPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>280, 20</value>
+    <value>349, 22</value>
   </data>
   <data name="txtCustomTaskCompletedSoundPath.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -1015,10 +1105,13 @@
     <value>9</value>
   </data>
   <data name="txtCustomCaptureSoundPath.Location" type="System.Drawing.Point, System.Drawing">
-    <value>248, 366</value>
+    <value>310, 458</value>
+  </data>
+  <data name="txtCustomCaptureSoundPath.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtCustomCaptureSoundPath.Size" type="System.Drawing.Size, System.Drawing">
-    <value>280, 20</value>
+    <value>349, 22</value>
   </data>
   <data name="txtCustomCaptureSoundPath.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -1042,10 +1135,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbUseCustomErrorSound.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 440</value>
+    <value>10, 550</value>
+  </data>
+  <data name="cbUseCustomErrorSound.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbUseCustomErrorSound.Size" type="System.Drawing.Size, System.Drawing">
-    <value>141, 17</value>
+    <value>186, 21</value>
   </data>
   <data name="cbUseCustomErrorSound.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -1072,10 +1168,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbUseCustomTaskCompletedSound.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 392</value>
+    <value>10, 490</value>
+  </data>
+  <data name="cbUseCustomTaskCompletedSound.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbUseCustomTaskCompletedSound.Size" type="System.Drawing.Size, System.Drawing">
-    <value>192, 17</value>
+    <value>250, 21</value>
   </data>
   <data name="cbUseCustomTaskCompletedSound.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -1102,10 +1201,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbUseCustomCaptureSound.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 368</value>
+    <value>10, 460</value>
+  </data>
+  <data name="cbUseCustomCaptureSound.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbUseCustomCaptureSound.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 17</value>
+    <value>203, 21</value>
   </data>
   <data name="cbUseCustomCaptureSound.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1129,10 +1231,13 @@
     <value>True</value>
   </data>
   <data name="cbToastWindowAutoHide.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 192</value>
+    <value>20, 240</value>
+  </data>
+  <data name="cbToastWindowAutoHide.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbToastWindowAutoHide.Size" type="System.Drawing.Size, System.Drawing">
-    <value>200, 17</value>
+    <value>263, 21</value>
   </data>
   <data name="cbToastWindowAutoHide.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -1159,10 +1264,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblToastWindowFadeDurationSeconds.Location" type="System.Drawing.Point, System.Drawing">
-    <value>237, 48</value>
+    <value>296, 60</value>
+  </data>
+  <data name="lblToastWindowFadeDurationSeconds.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblToastWindowFadeDurationSeconds.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>61, 17</value>
   </data>
   <data name="lblToastWindowFadeDurationSeconds.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1189,10 +1297,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblToastWindowDurationSeconds.Location" type="System.Drawing.Point, System.Drawing">
-    <value>237, 24</value>
+    <value>296, 30</value>
+  </data>
+  <data name="lblToastWindowDurationSeconds.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblToastWindowDurationSeconds.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>61, 17</value>
   </data>
   <data name="lblToastWindowDurationSeconds.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -1219,10 +1330,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblToastWindowSizeX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>263, 95</value>
+    <value>329, 119</value>
+  </data>
+  <data name="lblToastWindowSizeX.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblToastWindowSizeX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>12, 13</value>
+    <value>14, 17</value>
   </data>
   <data name="lblToastWindowSizeX.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -1243,10 +1357,13 @@
     <value>3</value>
   </data>
   <data name="cbToastWindowMiddleClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>176, 164</value>
+    <value>220, 205</value>
+  </data>
+  <data name="cbToastWindowMiddleClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbToastWindowMiddleClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>184, 21</value>
+    <value>229, 24</value>
   </data>
   <data name="cbToastWindowMiddleClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -1264,10 +1381,13 @@
     <value>4</value>
   </data>
   <data name="cbToastWindowRightClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>176, 140</value>
+    <value>220, 175</value>
+  </data>
+  <data name="cbToastWindowRightClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbToastWindowRightClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>184, 21</value>
+    <value>229, 24</value>
   </data>
   <data name="cbToastWindowRightClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -1285,10 +1405,13 @@
     <value>5</value>
   </data>
   <data name="cbToastWindowLeftClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>176, 116</value>
+    <value>220, 145</value>
+  </data>
+  <data name="cbToastWindowLeftClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbToastWindowLeftClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>184, 21</value>
+    <value>229, 24</value>
   </data>
   <data name="cbToastWindowLeftClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -1306,10 +1429,13 @@
     <value>6</value>
   </data>
   <data name="nudToastWindowSizeHeight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>280, 92</value>
+    <value>350, 115</value>
+  </data>
+  <data name="nudToastWindowSizeHeight.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudToastWindowSizeHeight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 20</value>
+    <value>100, 22</value>
   </data>
   <data name="nudToastWindowSizeHeight.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -1330,10 +1456,13 @@
     <value>7</value>
   </data>
   <data name="nudToastWindowSizeWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>176, 92</value>
+    <value>220, 115</value>
+  </data>
+  <data name="nudToastWindowSizeWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudToastWindowSizeWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>80, 20</value>
+    <value>100, 22</value>
   </data>
   <data name="nudToastWindowSizeWidth.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -1354,10 +1483,13 @@
     <value>8</value>
   </data>
   <data name="cbToastWindowPlacement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>176, 68</value>
+    <value>220, 85</value>
+  </data>
+  <data name="cbToastWindowPlacement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbToastWindowPlacement.Size" type="System.Drawing.Size, System.Drawing">
-    <value>184, 21</value>
+    <value>229, 24</value>
   </data>
   <data name="cbToastWindowPlacement.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1375,10 +1507,13 @@
     <value>9</value>
   </data>
   <data name="nudToastWindowFadeDuration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>176, 44</value>
+    <value>220, 55</value>
+  </data>
+  <data name="nudToastWindowFadeDuration.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudToastWindowFadeDuration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 20</value>
+    <value>70, 22</value>
   </data>
   <data name="nudToastWindowFadeDuration.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1405,10 +1540,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbDisableNotificationsOnFullscreen.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 216</value>
+    <value>20, 270</value>
+  </data>
+  <data name="cbDisableNotificationsOnFullscreen.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbDisableNotificationsOnFullscreen.Size" type="System.Drawing.Size, System.Drawing">
-    <value>209, 17</value>
+    <value>276, 21</value>
   </data>
   <data name="cbDisableNotificationsOnFullscreen.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -1429,10 +1567,13 @@
     <value>11</value>
   </data>
   <data name="nudToastWindowDuration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>176, 20</value>
+    <value>220, 25</value>
+  </data>
+  <data name="nudToastWindowDuration.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudToastWindowDuration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 20</value>
+    <value>70, 22</value>
   </data>
   <data name="nudToastWindowDuration.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1459,10 +1600,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblToastWindowMiddleClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 168</value>
+    <value>16, 210</value>
+  </data>
+  <data name="lblToastWindowMiddleClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblToastWindowMiddleClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 13</value>
+    <value>126, 17</value>
   </data>
   <data name="lblToastWindowMiddleClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -1489,10 +1633,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblToastWindowRightClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 144</value>
+    <value>16, 180</value>
+  </data>
+  <data name="lblToastWindowRightClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblToastWindowRightClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>92, 13</value>
+    <value>118, 17</value>
   </data>
   <data name="lblToastWindowRightClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -1519,10 +1666,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblToastWindowLeftClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 120</value>
+    <value>16, 150</value>
+  </data>
+  <data name="lblToastWindowLeftClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblToastWindowLeftClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>85, 13</value>
+    <value>109, 17</value>
   </data>
   <data name="lblToastWindowLeftClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -1549,10 +1699,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblToastWindowSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 96</value>
+    <value>16, 120</value>
+  </data>
+  <data name="lblToastWindowSize.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblToastWindowSize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 13</value>
+    <value>39, 17</value>
   </data>
   <data name="lblToastWindowSize.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -1579,10 +1732,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblToastWindowPlacement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 72</value>
+    <value>16, 90</value>
+  </data>
+  <data name="lblToastWindowPlacement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblToastWindowPlacement.Size" type="System.Drawing.Size, System.Drawing">
-    <value>60, 13</value>
+    <value>78, 17</value>
   </data>
   <data name="lblToastWindowPlacement.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -1609,10 +1765,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblToastWindowFadeDuration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 48</value>
+    <value>16, 60</value>
+  </data>
+  <data name="lblToastWindowFadeDuration.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblToastWindowFadeDuration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 13</value>
+    <value>100, 17</value>
   </data>
   <data name="lblToastWindowFadeDuration.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -1639,10 +1798,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblToastWindowDuration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>13, 24</value>
+    <value>16, 30</value>
+  </data>
+  <data name="lblToastWindowDuration.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblToastWindowDuration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 13</value>
+    <value>66, 17</value>
   </data>
   <data name="lblToastWindowDuration.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1663,10 +1825,16 @@
     <value>19</value>
   </data>
   <data name="gbToastWindow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 104</value>
+    <value>10, 130</value>
+  </data>
+  <data name="gbToastWindow.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="gbToastWindow.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="gbToastWindow.Size" type="System.Drawing.Size, System.Drawing">
-    <value>552, 248</value>
+    <value>690, 310</value>
   </data>
   <data name="gbToastWindow.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -1693,10 +1861,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbPlaySoundAfterCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
+    <value>10, 10</value>
+  </data>
+  <data name="cbPlaySoundAfterCapture.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbPlaySoundAfterCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>180, 17</value>
+    <value>238, 21</value>
   </data>
   <data name="cbPlaySoundAfterCapture.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1723,10 +1894,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbPlaySoundAfterUpload.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 32</value>
+    <value>10, 40</value>
+  </data>
+  <data name="cbPlaySoundAfterUpload.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbPlaySoundAfterUpload.Size" type="System.Drawing.Size, System.Drawing">
-    <value>187, 17</value>
+    <value>246, 21</value>
   </data>
   <data name="cbPlaySoundAfterUpload.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1747,13 +1921,16 @@
     <value>16</value>
   </data>
   <data name="tpNotifications.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpNotifications.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpNotifications.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpNotifications.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 453</value>
+    <value>698, 566</value>
   </data>
   <data name="tpNotifications.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -1777,10 +1954,13 @@
     <value>Fill</value>
   </data>
   <data name="tcGeneral.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 4</value>
+  </data>
+  <data name="tcGeneral.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tcGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>565, 479</value>
+    <value>708, 602</value>
   </data>
   <data name="tcGeneral.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -1798,13 +1978,16 @@
     <value>0</value>
   </data>
   <data name="tpGeneral.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpGeneral.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpGeneral.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 485</value>
+    <value>716, 610</value>
   </data>
   <data name="tpGeneral.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -1831,10 +2014,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbImageAutoJPEGQuality.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 256</value>
+    <value>10, 320</value>
+  </data>
+  <data name="cbImageAutoJPEGQuality.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbImageAutoJPEGQuality.Size" type="System.Drawing.Size, System.Drawing">
-    <value>400, 17</value>
+    <value>533, 21</value>
   </data>
   <data name="cbImageAutoJPEGQuality.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -1855,10 +2041,13 @@
     <value>0</value>
   </data>
   <data name="cbImagePNGBitDepth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 72</value>
+    <value>10, 90</value>
+  </data>
+  <data name="cbImagePNGBitDepth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbImagePNGBitDepth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>160, 21</value>
+    <value>199, 24</value>
   </data>
   <data name="cbImagePNGBitDepth.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -1882,10 +2071,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblImagePNGBitDepth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 56</value>
+    <value>6, 70</value>
+  </data>
+  <data name="lblImagePNGBitDepth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblImagePNGBitDepth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>77, 13</value>
+    <value>101, 17</value>
   </data>
   <data name="lblImagePNGBitDepth.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -1912,10 +2104,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbImageAutoUseJPEG.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 200</value>
+    <value>10, 250</value>
+  </data>
+  <data name="cbImageAutoUseJPEG.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbImageAutoUseJPEG.Size" type="System.Drawing.Size, System.Drawing">
-    <value>365, 17</value>
+    <value>489, 21</value>
   </data>
   <data name="cbImageAutoUseJPEG.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -1942,10 +2137,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblImageFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 8</value>
+    <value>6, 10</value>
+  </data>
+  <data name="lblImageFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblImageFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>71, 13</value>
+    <value>94, 17</value>
   </data>
   <data name="lblImageFormat.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -1966,10 +2164,13 @@
     <value>4</value>
   </data>
   <data name="cbImageFileExist.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 296</value>
+    <value>10, 370</value>
+  </data>
+  <data name="cbImageFileExist.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbImageFileExist.Size" type="System.Drawing.Size, System.Drawing">
-    <value>253, 21</value>
+    <value>315, 24</value>
   </data>
   <data name="cbImageFileExist.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -1993,10 +2194,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblImageFileExist.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 280</value>
+    <value>6, 350</value>
+  </data>
+  <data name="lblImageFileExist.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblImageFileExist.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 13</value>
+    <value>73, 17</value>
   </data>
   <data name="lblImageFileExist.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -2017,10 +2221,13 @@
     <value>6</value>
   </data>
   <data name="nudImageAutoUseJPEGSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 224</value>
+    <value>10, 280</value>
+  </data>
+  <data name="nudImageAutoUseJPEGSize.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudImageAutoUseJPEGSize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>72, 20</value>
+    <value>90, 22</value>
   </data>
   <data name="nudImageAutoUseJPEGSize.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -2047,10 +2254,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblImageSizeLimitHint.Location" type="System.Drawing.Point, System.Drawing">
-    <value>85, 228</value>
+    <value>106, 285</value>
+  </data>
+  <data name="lblImageSizeLimitHint.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblImageSizeLimitHint.Size" type="System.Drawing.Size, System.Drawing">
-    <value>20, 13</value>
+    <value>24, 17</value>
   </data>
   <data name="lblImageSizeLimitHint.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -2071,10 +2281,13 @@
     <value>8</value>
   </data>
   <data name="nudImageJPEGQuality.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 120</value>
+    <value>10, 150</value>
+  </data>
+  <data name="nudImageJPEGQuality.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudImageJPEGQuality.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 20</value>
+    <value>60, 22</value>
   </data>
   <data name="nudImageJPEGQuality.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -2095,10 +2308,13 @@
     <value>9</value>
   </data>
   <data name="cbImageFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 24</value>
+    <value>10, 30</value>
+  </data>
+  <data name="cbImageFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbImageFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 21</value>
+    <value>79, 24</value>
   </data>
   <data name="cbImageFormat.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2122,10 +2338,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblImageJPEGQualityHint.Location" type="System.Drawing.Point, System.Drawing">
-    <value>61, 124</value>
+    <value>76, 155</value>
+  </data>
+  <data name="lblImageJPEGQualityHint.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblImageJPEGQualityHint.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 13</value>
+    <value>53, 17</value>
   </data>
   <data name="lblImageJPEGQualityHint.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -2152,10 +2371,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblImageGIFQuality.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 152</value>
+    <value>6, 190</value>
+  </data>
+  <data name="lblImageGIFQuality.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblImageGIFQuality.Size" type="System.Drawing.Size, System.Drawing">
-    <value>60, 13</value>
+    <value>79, 17</value>
   </data>
   <data name="lblImageGIFQuality.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -2182,10 +2404,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblImageJPEGQuality.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 104</value>
+    <value>6, 130</value>
+  </data>
+  <data name="lblImageJPEGQuality.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblImageJPEGQuality.Size" type="System.Drawing.Size, System.Drawing">
-    <value>70, 13</value>
+    <value>93, 17</value>
   </data>
   <data name="lblImageJPEGQuality.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -2206,10 +2431,13 @@
     <value>13</value>
   </data>
   <data name="cbImageGIFQuality.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 168</value>
+    <value>10, 210</value>
+  </data>
+  <data name="cbImageGIFQuality.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbImageGIFQuality.Size" type="System.Drawing.Size, System.Drawing">
-    <value>360, 21</value>
+    <value>449, 24</value>
   </data>
   <data name="cbImageGIFQuality.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -2230,10 +2458,13 @@
     <value>Fill</value>
   </data>
   <data name="pImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
+    <value>0, 31</value>
+  </data>
+  <data name="pImage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="pImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 428</value>
+    <value>700, 542</value>
   </data>
   <data name="pImage.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2262,11 +2493,14 @@
   <data name="cbOverrideImageSettings.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="cbOverrideImageSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
   <data name="cbOverrideImageSettings.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 0</value>
+    <value>10, 10, 10, 0</value>
   </data>
   <data name="cbOverrideImageSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 25</value>
+    <value>700, 31</value>
   </data>
   <data name="cbOverrideImageSettings.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2287,10 +2521,13 @@
     <value>1</value>
   </data>
   <data name="tpQuality.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpQuality.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpQuality.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 453</value>
+    <value>700, 573</value>
   </data>
   <data name="tpQuality.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2311,10 +2548,13 @@
     <value>True</value>
   </data>
   <data name="cbUseRandomImageEffect.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 112</value>
+    <value>10, 140</value>
+  </data>
+  <data name="cbUseRandomImageEffect.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbUseRandomImageEffect.Size" type="System.Drawing.Size, System.Drawing">
-    <value>144, 17</value>
+    <value>188, 21</value>
   </data>
   <data name="cbUseRandomImageEffect.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -2341,10 +2581,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblImageEffectsNote.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 8</value>
+    <value>6, 10</value>
+  </data>
+  <data name="lblImageEffectsNote.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblImageEffectsNote.Size" type="System.Drawing.Size, System.Drawing">
-    <value>443, 13</value>
+    <value>585, 17</value>
   </data>
   <data name="lblImageEffectsNote.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2371,10 +2614,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbShowImageEffectsWindowAfterCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 64</value>
+    <value>10, 80</value>
+  </data>
+  <data name="cbShowImageEffectsWindowAfterCapture.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbShowImageEffectsWindowAfterCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>221, 17</value>
+    <value>286, 21</value>
   </data>
   <data name="cbShowImageEffectsWindowAfterCapture.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -2401,10 +2647,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbImageEffectOnlyRegionCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 88</value>
+    <value>10, 110</value>
+  </data>
+  <data name="cbImageEffectOnlyRegionCapture.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbImageEffectOnlyRegionCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>193, 17</value>
+    <value>255, 21</value>
   </data>
   <data name="cbImageEffectOnlyRegionCapture.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -2428,10 +2677,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnImageEffects.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 32</value>
+    <value>10, 40</value>
+  </data>
+  <data name="btnImageEffects.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnImageEffects.Size" type="System.Drawing.Size, System.Drawing">
-    <value>208, 23</value>
+    <value>260, 29</value>
   </data>
   <data name="btnImageEffects.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2452,13 +2704,16 @@
     <value>4</value>
   </data>
   <data name="tpEffects.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpEffects.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpEffects.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpEffects.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 453</value>
+    <value>698, 566</value>
   </data>
   <data name="tpEffects.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -2485,10 +2740,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbThumbnailIfSmaller.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 152</value>
+    <value>14, 190</value>
+  </data>
+  <data name="cbThumbnailIfSmaller.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbThumbnailIfSmaller.Size" type="System.Drawing.Size, System.Drawing">
-    <value>322, 17</value>
+    <value>433, 21</value>
   </data>
   <data name="cbThumbnailIfSmaller.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -2515,10 +2773,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblThumbnailNamePreview.Location" type="System.Drawing.Point, System.Drawing">
-    <value>147, 124</value>
+    <value>184, 155</value>
+  </data>
+  <data name="lblThumbnailNamePreview.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblThumbnailNamePreview.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 13</value>
+    <value>57, 17</value>
   </data>
   <data name="lblThumbnailNamePreview.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -2545,10 +2806,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblThumbnailName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 104</value>
+    <value>10, 130</value>
+  </data>
+  <data name="lblThumbnailName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblThumbnailName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 13</value>
+    <value>117, 17</value>
   </data>
   <data name="lblThumbnailName.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -2569,10 +2833,13 @@
     <value>2</value>
   </data>
   <data name="txtThumbnailName.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 120</value>
+    <value>14, 150</value>
+  </data>
+  <data name="txtThumbnailName.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtThumbnailName.Size" type="System.Drawing.Size, System.Drawing">
-    <value>128, 20</value>
+    <value>159, 22</value>
   </data>
   <data name="txtThumbnailName.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -2596,10 +2863,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblThumbnailHeight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 56</value>
+    <value>10, 70</value>
+  </data>
+  <data name="lblThumbnailHeight.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblThumbnailHeight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 13</value>
+    <value>53, 17</value>
   </data>
   <data name="lblThumbnailHeight.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -2626,10 +2896,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblThumbnailWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
+    <value>10, 10</value>
+  </data>
+  <data name="lblThumbnailWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblThumbnailWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+    <value>48, 17</value>
   </data>
   <data name="lblThumbnailWidth.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2650,10 +2923,13 @@
     <value>5</value>
   </data>
   <data name="nudThumbnailHeight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 72</value>
+    <value>14, 90</value>
+  </data>
+  <data name="nudThumbnailHeight.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudThumbnailHeight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
+    <value>80, 22</value>
   </data>
   <data name="nudThumbnailHeight.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -2674,10 +2950,13 @@
     <value>6</value>
   </data>
   <data name="nudThumbnailWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 24</value>
+    <value>14, 30</value>
+  </data>
+  <data name="nudThumbnailWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudThumbnailWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
+    <value>80, 22</value>
   </data>
   <data name="nudThumbnailWidth.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2698,13 +2977,16 @@
     <value>7</value>
   </data>
   <data name="tpThumbnail.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpThumbnail.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpThumbnail.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpThumbnail.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 453</value>
+    <value>698, 566</value>
   </data>
   <data name="tpThumbnail.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -2728,10 +3010,13 @@
     <value>Fill</value>
   </data>
   <data name="tcImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 4</value>
+  </data>
+  <data name="tcImage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tcImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>565, 479</value>
+    <value>708, 602</value>
   </data>
   <data name="tcImage.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -2749,13 +3034,16 @@
     <value>0</value>
   </data>
   <data name="tpImage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpImage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpImage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpImage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 485</value>
+    <value>716, 610</value>
   </data>
   <data name="tpImage.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2775,11 +3063,44 @@
   <data name="&gt;&gt;tpImage.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
+  <data name="cbUseWinRTCapture.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="cbUseWinRTCapture.Location" type="System.Drawing.Point, System.Drawing">
+    <value>10, 410</value>
+  </data>
+  <data name="cbUseWinRTCapture.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
+  <data name="cbUseWinRTCapture.Size" type="System.Drawing.Size, System.Drawing">
+    <value>273, 21</value>
+  </data>
+  <data name="cbUseWinRTCapture.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="cbUseWinRTCapture.Text" xml:space="preserve">
+    <value>Use WinRT API (HDR color correction)</value>
+  </data>
+  <data name="&gt;&gt;cbUseWinRTCapture.Name" xml:space="preserve">
+    <value>cbUseWinRTCapture</value>
+  </data>
+  <data name="&gt;&gt;cbUseWinRTCapture.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;cbUseWinRTCapture.Parent" xml:space="preserve">
+    <value>pCapture</value>
+  </data>
+  <data name="&gt;&gt;cbUseWinRTCapture.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="txtCaptureCustomWindow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 304</value>
+    <value>10, 380</value>
+  </data>
+  <data name="txtCaptureCustomWindow.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtCaptureCustomWindow.Size" type="System.Drawing.Size, System.Drawing">
-    <value>360, 20</value>
+    <value>449, 22</value>
   </data>
   <data name="txtCaptureCustomWindow.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -2794,16 +3115,19 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;txtCaptureCustomWindow.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="lblCaptureCustomWindow.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="lblCaptureCustomWindow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 288</value>
+    <value>6, 360</value>
+  </data>
+  <data name="lblCaptureCustomWindow.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblCaptureCustomWindow.Size" type="System.Drawing.Size, System.Drawing">
-    <value>137, 13</value>
+    <value>180, 17</value>
   </data>
   <data name="lblCaptureCustomWindow.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -2821,7 +3145,7 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;lblCaptureCustomWindow.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="lblScreenshotDelay.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2830,10 +3154,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblScreenshotDelay.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 30</value>
+    <value>6, 38</value>
+  </data>
+  <data name="lblScreenshotDelay.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblScreenshotDelay.Size" type="System.Drawing.Size, System.Drawing">
-    <value>92, 13</value>
+    <value>122, 17</value>
   </data>
   <data name="lblScreenshotDelay.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -2851,16 +3178,19 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;lblScreenshotDelay.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="btnCaptureCustomRegionSelectRectangle.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="btnCaptureCustomRegionSelectRectangle.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 255</value>
+    <value>290, 319</value>
+  </data>
+  <data name="btnCaptureCustomRegionSelectRectangle.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnCaptureCustomRegionSelectRectangle.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 23</value>
+    <value>170, 29</value>
   </data>
   <data name="btnCaptureCustomRegionSelectRectangle.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -2878,7 +3208,7 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;btnCaptureCustomRegionSelectRectangle.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="lblCaptureCustomRegion.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2887,10 +3217,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblCaptureCustomRegion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 224</value>
+    <value>6, 280</value>
+  </data>
+  <data name="lblCaptureCustomRegion.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblCaptureCustomRegion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 13</value>
+    <value>149, 17</value>
   </data>
   <data name="lblCaptureCustomRegion.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -2908,7 +3241,7 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;lblCaptureCustomRegion.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="lblCaptureCustomRegionWidth.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2917,10 +3250,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblCaptureCustomRegionWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 240</value>
+    <value>146, 300</value>
+  </data>
+  <data name="lblCaptureCustomRegionWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblCaptureCustomRegionWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>35, 13</value>
+    <value>44, 17</value>
   </data>
   <data name="lblCaptureCustomRegionWidth.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -2938,7 +3274,7 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;lblCaptureCustomRegionWidth.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="lblCaptureCustomRegionHeight.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2947,10 +3283,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblCaptureCustomRegionHeight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>173, 240</value>
+    <value>216, 300</value>
+  </data>
+  <data name="lblCaptureCustomRegionHeight.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblCaptureCustomRegionHeight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+    <value>49, 17</value>
   </data>
   <data name="lblCaptureCustomRegionHeight.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -2968,7 +3307,7 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;lblCaptureCustomRegionHeight.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="lblCaptureCustomRegionY.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -2977,10 +3316,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblCaptureCustomRegionY.Location" type="System.Drawing.Point, System.Drawing">
-    <value>61, 240</value>
+    <value>76, 300</value>
+  </data>
+  <data name="lblCaptureCustomRegionY.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblCaptureCustomRegionY.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
+    <value>17, 17</value>
   </data>
   <data name="lblCaptureCustomRegionY.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -2998,7 +3340,7 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;lblCaptureCustomRegionY.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="lblCaptureCustomRegionX.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3007,10 +3349,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblCaptureCustomRegionX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 240</value>
+    <value>6, 300</value>
+  </data>
+  <data name="lblCaptureCustomRegionX.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblCaptureCustomRegionX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>14, 13</value>
+    <value>17, 17</value>
   </data>
   <data name="lblCaptureCustomRegionX.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -3028,13 +3373,16 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;lblCaptureCustomRegionX.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="nudCaptureCustomRegionHeight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>176, 256</value>
+    <value>220, 320</value>
+  </data>
+  <data name="nudCaptureCustomRegionHeight.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudCaptureCustomRegionHeight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 20</value>
+    <value>62, 22</value>
   </data>
   <data name="nudCaptureCustomRegionHeight.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -3049,13 +3397,16 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;nudCaptureCustomRegionHeight.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="nudCaptureCustomRegionWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>120, 256</value>
+    <value>150, 320</value>
+  </data>
+  <data name="nudCaptureCustomRegionWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudCaptureCustomRegionWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 20</value>
+    <value>62, 22</value>
   </data>
   <data name="nudCaptureCustomRegionWidth.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -3070,13 +3421,16 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;nudCaptureCustomRegionWidth.ZOrder" xml:space="preserve">
-    <value>10</value>
+    <value>11</value>
   </data>
   <data name="nudCaptureCustomRegionY.Location" type="System.Drawing.Point, System.Drawing">
-    <value>64, 256</value>
+    <value>80, 320</value>
+  </data>
+  <data name="nudCaptureCustomRegionY.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudCaptureCustomRegionY.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 20</value>
+    <value>62, 22</value>
   </data>
   <data name="nudCaptureCustomRegionY.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -3091,13 +3445,16 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;nudCaptureCustomRegionY.ZOrder" xml:space="preserve">
-    <value>11</value>
+    <value>12</value>
   </data>
   <data name="nudCaptureCustomRegionX.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 256</value>
+    <value>10, 320</value>
+  </data>
+  <data name="nudCaptureCustomRegionX.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudCaptureCustomRegionX.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 20</value>
+    <value>62, 22</value>
   </data>
   <data name="nudCaptureCustomRegionX.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -3112,7 +3469,7 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;nudCaptureCustomRegionX.ZOrder" xml:space="preserve">
-    <value>12</value>
+    <value>13</value>
   </data>
   <data name="cbShowCursor.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3121,10 +3478,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbShowCursor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
+    <value>10, 10</value>
+  </data>
+  <data name="cbShowCursor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbShowCursor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>156, 17</value>
+    <value>204, 21</value>
   </data>
   <data name="cbShowCursor.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -3142,7 +3502,7 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;cbShowCursor.ZOrder" xml:space="preserve">
-    <value>13</value>
+    <value>14</value>
   </data>
   <data name="lblCaptureShadowOffset.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3151,10 +3511,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblCaptureShadowOffset.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 126</value>
+    <value>6, 158</value>
+  </data>
+  <data name="lblCaptureShadowOffset.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblCaptureShadowOffset.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 13</value>
+    <value>101, 17</value>
   </data>
   <data name="lblCaptureShadowOffset.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -3172,7 +3535,7 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;lblCaptureShadowOffset.ZOrder" xml:space="preserve">
-    <value>14</value>
+    <value>15</value>
   </data>
   <data name="cbCaptureTransparent.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3181,10 +3544,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbCaptureTransparent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 80</value>
+    <value>10, 100</value>
+  </data>
+  <data name="cbCaptureTransparent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbCaptureTransparent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 17</value>
+    <value>244, 21</value>
   </data>
   <data name="cbCaptureTransparent.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -3202,7 +3568,7 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;cbCaptureTransparent.ZOrder" xml:space="preserve">
-    <value>15</value>
+    <value>16</value>
   </data>
   <data name="cbCaptureAutoHideTaskbar.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3211,10 +3577,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbCaptureAutoHideTaskbar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 200</value>
+    <value>10, 250</value>
+  </data>
+  <data name="cbCaptureAutoHideTaskbar.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbCaptureAutoHideTaskbar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>402, 17</value>
+    <value>525, 21</value>
   </data>
   <data name="cbCaptureAutoHideTaskbar.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -3232,7 +3601,7 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;cbCaptureAutoHideTaskbar.ZOrder" xml:space="preserve">
-    <value>16</value>
+    <value>17</value>
   </data>
   <data name="cbCaptureShadow.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3241,10 +3610,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbCaptureShadow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 104</value>
+    <value>10, 130</value>
+  </data>
+  <data name="cbCaptureShadow.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbCaptureShadow.Size" type="System.Drawing.Size, System.Drawing">
-    <value>274, 17</value>
+    <value>362, 21</value>
   </data>
   <data name="cbCaptureShadow.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -3262,7 +3634,7 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;cbCaptureShadow.ZOrder" xml:space="preserve">
-    <value>17</value>
+    <value>18</value>
   </data>
   <data name="lblScreenshotDelayInfo.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3271,10 +3643,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblScreenshotDelayInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>72, 52</value>
+    <value>90, 65</value>
+  </data>
+  <data name="lblScreenshotDelayInfo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblScreenshotDelayInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>61, 17</value>
   </data>
   <data name="lblScreenshotDelayInfo.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -3292,7 +3667,7 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;lblScreenshotDelayInfo.ZOrder" xml:space="preserve">
-    <value>18</value>
+    <value>19</value>
   </data>
   <data name="cbCaptureClientArea.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -3301,10 +3676,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbCaptureClientArea.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 176</value>
+    <value>10, 220</value>
+  </data>
+  <data name="cbCaptureClientArea.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbCaptureClientArea.Size" type="System.Drawing.Size, System.Drawing">
-    <value>334, 17</value>
+    <value>434, 21</value>
   </data>
   <data name="cbCaptureClientArea.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -3322,13 +3700,16 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;cbCaptureClientArea.ZOrder" xml:space="preserve">
-    <value>19</value>
+    <value>20</value>
   </data>
   <data name="nudScreenshotDelay.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 48</value>
+    <value>10, 60</value>
+  </data>
+  <data name="nudScreenshotDelay.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudScreenshotDelay.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 20</value>
+    <value>70, 22</value>
   </data>
   <data name="nudScreenshotDelay.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -3346,13 +3727,16 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;nudScreenshotDelay.ZOrder" xml:space="preserve">
-    <value>20</value>
+    <value>21</value>
   </data>
   <data name="nudCaptureShadowOffset.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 144</value>
+    <value>10, 180</value>
+  </data>
+  <data name="nudCaptureShadowOffset.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudCaptureShadowOffset.Size" type="System.Drawing.Size, System.Drawing">
-    <value>56, 20</value>
+    <value>70, 22</value>
   </data>
   <data name="nudCaptureShadowOffset.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -3370,16 +3754,19 @@
     <value>pCapture</value>
   </data>
   <data name="&gt;&gt;nudCaptureShadowOffset.ZOrder" xml:space="preserve">
-    <value>21</value>
+    <value>22</value>
   </data>
   <data name="pCapture.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
   <data name="pCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
+    <value>0, 31</value>
+  </data>
+  <data name="pCapture.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="pCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 428</value>
+    <value>700, 542</value>
   </data>
   <data name="pCapture.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -3408,11 +3795,14 @@
   <data name="cbOverrideCaptureSettings.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="cbOverrideCaptureSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
   <data name="cbOverrideCaptureSettings.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 0</value>
+    <value>10, 10, 10, 0</value>
   </data>
   <data name="cbOverrideCaptureSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 25</value>
+    <value>700, 31</value>
   </data>
   <data name="cbOverrideCaptureSettings.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -3433,10 +3823,13 @@
     <value>1</value>
   </data>
   <data name="tpCaptureGeneral.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpCaptureGeneral.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpCaptureGeneral.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 453</value>
+    <value>700, 573</value>
   </data>
   <data name="tpCaptureGeneral.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -3457,10 +3850,13 @@
     <value>True</value>
   </data>
   <data name="lblRegionCaptureBackgroundDimStrengthHint.Location" type="System.Drawing.Point, System.Drawing">
-    <value>365, 176</value>
+    <value>456, 220</value>
+  </data>
+  <data name="lblRegionCaptureBackgroundDimStrengthHint.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblRegionCaptureBackgroundDimStrengthHint.Size" type="System.Drawing.Size, System.Drawing">
-    <value>15, 13</value>
+    <value>20, 17</value>
   </data>
   <data name="lblRegionCaptureBackgroundDimStrengthHint.TabIndex" type="System.Int32, mscorlib">
     <value>36</value>
@@ -3481,10 +3877,13 @@
     <value>0</value>
   </data>
   <data name="nudRegionCaptureBackgroundDimStrength.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 172</value>
+    <value>390, 215</value>
+  </data>
+  <data name="nudRegionCaptureBackgroundDimStrength.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudRegionCaptureBackgroundDimStrength.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 20</value>
+    <value>60, 22</value>
   </data>
   <data name="nudRegionCaptureBackgroundDimStrength.TabIndex" type="System.Int32, mscorlib">
     <value>35</value>
@@ -3508,10 +3907,13 @@
     <value>True</value>
   </data>
   <data name="lblRegionCaptureBackgroundDimStrength.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 176</value>
+    <value>6, 220</value>
+  </data>
+  <data name="lblRegionCaptureBackgroundDimStrength.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblRegionCaptureBackgroundDimStrength.Size" type="System.Drawing.Size, System.Drawing">
-    <value>128, 13</value>
+    <value>170, 17</value>
   </data>
   <data name="lblRegionCaptureBackgroundDimStrength.TabIndex" type="System.Int32, mscorlib">
     <value>34</value>
@@ -3535,10 +3937,13 @@
     <value>True</value>
   </data>
   <data name="cbRegionCaptureActiveMonitorMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 464</value>
+    <value>10, 580</value>
+  </data>
+  <data name="cbRegionCaptureActiveMonitorMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureActiveMonitorMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>303, 17</value>
+    <value>401, 21</value>
   </data>
   <data name="cbRegionCaptureActiveMonitorMode.TabIndex" type="System.Int32, mscorlib">
     <value>33</value>
@@ -3559,10 +3964,13 @@
     <value>3</value>
   </data>
   <data name="nudRegionCaptureFPSLimit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 436</value>
+    <value>390, 545</value>
+  </data>
+  <data name="nudRegionCaptureFPSLimit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudRegionCaptureFPSLimit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
+    <value>80, 22</value>
   </data>
   <data name="nudRegionCaptureFPSLimit.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>
@@ -3586,10 +3994,13 @@
     <value>True</value>
   </data>
   <data name="lblRegionCaptureFPSLimit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 440</value>
+    <value>6, 550</value>
+  </data>
+  <data name="lblRegionCaptureFPSLimit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblRegionCaptureFPSLimit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 13</value>
+    <value>66, 17</value>
   </data>
   <data name="lblRegionCaptureFPSLimit.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -3616,10 +4027,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbRegionCaptureShowFPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 416</value>
+    <value>10, 520</value>
+  </data>
+  <data name="cbRegionCaptureShowFPS.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureShowFPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 17</value>
+    <value>94, 21</value>
   </data>
   <data name="cbRegionCaptureShowFPS.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -3661,7 +4075,7 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="lblRegionCaptureFixedSizeWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+    <value>48, 17</value>
   </data>
   <data name="lblRegionCaptureFixedSizeWidth.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -3682,10 +4096,13 @@
     <value>0</value>
   </data>
   <data name="nudRegionCaptureFixedSizeWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>41, 3</value>
+    <value>52, 4</value>
+  </data>
+  <data name="nudRegionCaptureFixedSizeWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudRegionCaptureFixedSizeWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
+    <value>80, 22</value>
   </data>
   <data name="nudRegionCaptureFixedSizeWidth.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -3715,13 +4132,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblRegionCaptureFixedSizeHeight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>111, 6</value>
+    <value>140, 6</value>
   </data>
   <data name="lblRegionCaptureFixedSizeHeight.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 0, 0</value>
+    <value>4, 0, 0, 0</value>
   </data>
   <data name="lblRegionCaptureFixedSizeHeight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 13</value>
+    <value>53, 17</value>
   </data>
   <data name="lblRegionCaptureFixedSizeHeight.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -3742,10 +4159,13 @@
     <value>2</value>
   </data>
   <data name="nudRegionCaptureFixedSizeHeight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>155, 3</value>
+    <value>197, 4</value>
+  </data>
+  <data name="nudRegionCaptureFixedSizeHeight.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudRegionCaptureFixedSizeHeight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
+    <value>80, 22</value>
   </data>
   <data name="nudRegionCaptureFixedSizeHeight.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -3766,10 +4186,13 @@
     <value>3</value>
   </data>
   <data name="flpRegionCaptureFixedSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 387</value>
+    <value>390, 484</value>
+  </data>
+  <data name="flpRegionCaptureFixedSize.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="flpRegionCaptureFixedSize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 26</value>
+    <value>281, 30</value>
   </data>
   <data name="flpRegionCaptureFixedSize.TabIndex" type="System.Int32, mscorlib">
     <value>29</value>
@@ -3796,10 +4219,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbRegionCaptureIsFixedSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 392</value>
+    <value>10, 490</value>
+  </data>
+  <data name="cbRegionCaptureIsFixedSize.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureIsFixedSize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>136, 17</value>
+    <value>179, 21</value>
   </data>
   <data name="cbRegionCaptureIsFixedSize.TabIndex" type="System.Int32, mscorlib">
     <value>28</value>
@@ -3826,10 +4252,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbRegionCaptureShowCrosshair.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 368</value>
+    <value>10, 460</value>
+  </data>
+  <data name="cbRegionCaptureShowCrosshair.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureShowCrosshair.Size" type="System.Drawing.Size, System.Drawing">
-    <value>158, 17</value>
+    <value>205, 21</value>
   </data>
   <data name="cbRegionCaptureShowCrosshair.TabIndex" type="System.Int32, mscorlib">
     <value>27</value>
@@ -3856,10 +4285,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblRegionCaptureMagnifierPixelSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 344</value>
+    <value>6, 430</value>
+  </data>
+  <data name="lblRegionCaptureMagnifierPixelSize.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblRegionCaptureMagnifierPixelSize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>98, 13</value>
+    <value>131, 17</value>
   </data>
   <data name="lblRegionCaptureMagnifierPixelSize.TabIndex" type="System.Int32, mscorlib">
     <value>25</value>
@@ -3886,10 +4318,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblRegionCaptureMagnifierPixelCount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 320</value>
+    <value>6, 400</value>
+  </data>
+  <data name="lblRegionCaptureMagnifierPixelCount.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblRegionCaptureMagnifierPixelCount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 13</value>
+    <value>141, 17</value>
   </data>
   <data name="lblRegionCaptureMagnifierPixelCount.TabIndex" type="System.Int32, mscorlib">
     <value>23</value>
@@ -3916,10 +4351,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbRegionCaptureUseSquareMagnifier.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 296</value>
+    <value>10, 370</value>
+  </data>
+  <data name="cbRegionCaptureUseSquareMagnifier.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureUseSquareMagnifier.Size" type="System.Drawing.Size, System.Drawing">
-    <value>234, 17</value>
+    <value>311, 21</value>
   </data>
   <data name="cbRegionCaptureUseSquareMagnifier.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -3946,10 +4384,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbRegionCaptureShowMagnifier.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 272</value>
+    <value>10, 340</value>
+  </data>
+  <data name="cbRegionCaptureShowMagnifier.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureShowMagnifier.Size" type="System.Drawing.Size, System.Drawing">
-    <value>154, 17</value>
+    <value>203, 21</value>
   </data>
   <data name="cbRegionCaptureShowMagnifier.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -3976,10 +4417,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbRegionCaptureShowInfo.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 248</value>
+    <value>10, 310</value>
+  </data>
+  <data name="cbRegionCaptureShowInfo.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureShowInfo.Size" type="System.Drawing.Size, System.Drawing">
-    <value>154, 17</value>
+    <value>201, 21</value>
   </data>
   <data name="cbRegionCaptureShowInfo.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -4003,10 +4447,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnRegionCaptureSnapSizesRemove.Location" type="System.Drawing.Point, System.Drawing">
-    <value>504, 218</value>
+    <value>630, 272</value>
+  </data>
+  <data name="btnRegionCaptureSnapSizesRemove.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnRegionCaptureSnapSizesRemove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 24</value>
+    <value>30, 30</value>
   </data>
   <data name="btnRegionCaptureSnapSizesRemove.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -4030,10 +4477,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnRegionCaptureSnapSizesAdd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>480, 218</value>
+    <value>600, 272</value>
+  </data>
+  <data name="btnRegionCaptureSnapSizesAdd.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnRegionCaptureSnapSizesAdd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>24, 24</value>
+    <value>30, 30</value>
   </data>
   <data name="btnRegionCaptureSnapSizesAdd.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -4054,10 +4504,13 @@
     <value>16</value>
   </data>
   <data name="cbRegionCaptureSnapSizes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 220</value>
+    <value>390, 275</value>
+  </data>
+  <data name="cbRegionCaptureSnapSizes.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureSnapSizes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>167, 21</value>
+    <value>208, 24</value>
   </data>
   <data name="cbRegionCaptureSnapSizes.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -4081,10 +4534,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblRegionCaptureSnapSizes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 224</value>
+    <value>6, 280</value>
+  </data>
+  <data name="lblRegionCaptureSnapSizes.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblRegionCaptureSnapSizes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>233, 13</value>
+    <value>306, 17</value>
   </data>
   <data name="lblRegionCaptureSnapSizes.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -4111,10 +4567,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbRegionCaptureUseCustomInfoText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 200</value>
+    <value>10, 250</value>
+  </data>
+  <data name="cbRegionCaptureUseCustomInfoText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureUseCustomInfoText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>181, 17</value>
+    <value>238, 21</value>
   </data>
   <data name="cbRegionCaptureUseCustomInfoText.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -4141,10 +4600,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbRegionCaptureDetectControls.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 152</value>
+    <value>10, 190</value>
+  </data>
+  <data name="cbRegionCaptureDetectControls.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureDetectControls.Size" type="System.Drawing.Size, System.Drawing">
-    <value>225, 17</value>
+    <value>295, 21</value>
   </data>
   <data name="cbRegionCaptureDetectControls.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -4171,10 +4633,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbRegionCaptureDetectWindows.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 128</value>
+    <value>10, 160</value>
+  </data>
+  <data name="cbRegionCaptureDetectWindows.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureDetectWindows.Size" type="System.Drawing.Size, System.Drawing">
-    <value>283, 17</value>
+    <value>370, 21</value>
   </data>
   <data name="cbRegionCaptureDetectWindows.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -4195,10 +4660,13 @@
     <value>21</value>
   </data>
   <data name="cbRegionCaptureMouse5ClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 100</value>
+    <value>390, 125</value>
+  </data>
+  <data name="cbRegionCaptureMouse5ClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureMouse5ClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>216, 21</value>
+    <value>269, 24</value>
   </data>
   <data name="cbRegionCaptureMouse5ClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -4222,10 +4690,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblRegionCaptureMouse5ClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 104</value>
+    <value>6, 130</value>
+  </data>
+  <data name="lblRegionCaptureMouse5ClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblRegionCaptureMouse5ClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>108, 13</value>
+    <value>139, 17</value>
   </data>
   <data name="lblRegionCaptureMouse5ClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -4246,10 +4717,13 @@
     <value>23</value>
   </data>
   <data name="cbRegionCaptureMouse4ClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 76</value>
+    <value>390, 95</value>
+  </data>
+  <data name="cbRegionCaptureMouse4ClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureMouse4ClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>216, 21</value>
+    <value>269, 24</value>
   </data>
   <data name="cbRegionCaptureMouse4ClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -4273,10 +4747,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblRegionCaptureMouse4ClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 80</value>
+    <value>6, 100</value>
+  </data>
+  <data name="lblRegionCaptureMouse4ClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblRegionCaptureMouse4ClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>108, 13</value>
+    <value>139, 17</value>
   </data>
   <data name="lblRegionCaptureMouse4ClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -4297,10 +4774,13 @@
     <value>25</value>
   </data>
   <data name="cbRegionCaptureMouseMiddleClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 52</value>
+    <value>390, 65</value>
+  </data>
+  <data name="cbRegionCaptureMouseMiddleClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureMouseMiddleClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>216, 21</value>
+    <value>269, 24</value>
   </data>
   <data name="cbRegionCaptureMouseMiddleClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -4324,10 +4804,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblRegionCaptureMouseMiddleClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 56</value>
+    <value>6, 70</value>
+  </data>
+  <data name="lblRegionCaptureMouseMiddleClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblRegionCaptureMouseMiddleClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>132, 13</value>
+    <value>172, 17</value>
   </data>
   <data name="lblRegionCaptureMouseMiddleClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -4348,10 +4831,13 @@
     <value>27</value>
   </data>
   <data name="cbRegionCaptureMouseRightClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 28</value>
+    <value>390, 35</value>
+  </data>
+  <data name="cbRegionCaptureMouseRightClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureMouseRightClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>216, 21</value>
+    <value>269, 24</value>
   </data>
   <data name="cbRegionCaptureMouseRightClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -4375,10 +4861,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblRegionCaptureMouseRightClickAction.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 32</value>
+    <value>6, 40</value>
+  </data>
+  <data name="lblRegionCaptureMouseRightClickAction.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblRegionCaptureMouseRightClickAction.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 13</value>
+    <value>159, 17</value>
   </data>
   <data name="lblRegionCaptureMouseRightClickAction.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -4405,10 +4894,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbRegionCaptureMultiRegionMode.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
+    <value>10, 10</value>
+  </data>
+  <data name="cbRegionCaptureMultiRegionMode.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbRegionCaptureMultiRegionMode.Size" type="System.Drawing.Size, System.Drawing">
-    <value>360, 17</value>
+    <value>478, 21</value>
   </data>
   <data name="cbRegionCaptureMultiRegionMode.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -4432,10 +4924,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnRegionCaptureSnapSizesDialogCancel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>120, 80</value>
+    <value>150, 100</value>
+  </data>
+  <data name="btnRegionCaptureSnapSizesDialogCancel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnRegionCaptureSnapSizesDialogCancel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 24</value>
+    <value>130, 30</value>
   </data>
   <data name="btnRegionCaptureSnapSizesDialogCancel.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -4459,10 +4954,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnRegionCaptureSnapSizesDialogAdd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 80</value>
+    <value>10, 100</value>
+  </data>
+  <data name="btnRegionCaptureSnapSizesDialogAdd.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnRegionCaptureSnapSizesDialogAdd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 24</value>
+    <value>130, 30</value>
   </data>
   <data name="btnRegionCaptureSnapSizesDialogAdd.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -4483,10 +4981,13 @@
     <value>1</value>
   </data>
   <data name="nudRegionCaptureSnapSizesHeight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>120, 56</value>
+    <value>150, 70</value>
+  </data>
+  <data name="nudRegionCaptureSnapSizesHeight.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudRegionCaptureSnapSizesHeight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 20</value>
+    <value>130, 22</value>
   </data>
   <data name="nudRegionCaptureSnapSizesHeight.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -4513,10 +5014,13 @@
     <value>NoControl</value>
   </data>
   <data name="RegionCaptureSnapSizesHeight.Location" type="System.Drawing.Point, System.Drawing">
-    <value>117, 40</value>
+    <value>146, 50</value>
+  </data>
+  <data name="RegionCaptureSnapSizesHeight.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="RegionCaptureSnapSizesHeight.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 13</value>
+    <value>53, 17</value>
   </data>
   <data name="RegionCaptureSnapSizesHeight.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -4537,10 +5041,13 @@
     <value>3</value>
   </data>
   <data name="nudRegionCaptureSnapSizesWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 56</value>
+    <value>10, 70</value>
+  </data>
+  <data name="nudRegionCaptureSnapSizesWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudRegionCaptureSnapSizesWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 20</value>
+    <value>130, 22</value>
   </data>
   <data name="nudRegionCaptureSnapSizesWidth.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -4567,10 +5074,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblRegionCaptureSnapSizesWidth.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 40</value>
+    <value>6, 50</value>
+  </data>
+  <data name="lblRegionCaptureSnapSizesWidth.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblRegionCaptureSnapSizesWidth.Size" type="System.Drawing.Size, System.Drawing">
-    <value>38, 13</value>
+    <value>48, 17</value>
   </data>
   <data name="lblRegionCaptureSnapSizesWidth.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -4591,10 +5101,13 @@
     <value>5</value>
   </data>
   <data name="pRegionCaptureSnapSizes.Location" type="System.Drawing.Point, System.Drawing">
-    <value>304, 208</value>
+    <value>380, 260</value>
+  </data>
+  <data name="pRegionCaptureSnapSizes.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="pRegionCaptureSnapSizes.Size" type="System.Drawing.Size, System.Drawing">
-    <value>232, 112</value>
+    <value>290, 140</value>
   </data>
   <data name="pRegionCaptureSnapSizes.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -4615,10 +5128,13 @@
     <value>31</value>
   </data>
   <data name="txtRegionCaptureCustomInfoText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 198</value>
+    <value>390, 248</value>
+  </data>
+  <data name="txtRegionCaptureCustomInfoText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtRegionCaptureCustomInfoText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>216, 20</value>
+    <value>269, 22</value>
   </data>
   <data name="txtRegionCaptureCustomInfoText.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -4636,10 +5152,13 @@
     <value>32</value>
   </data>
   <data name="nudRegionCaptureMagnifierPixelCount.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 316</value>
+    <value>390, 395</value>
+  </data>
+  <data name="nudRegionCaptureMagnifierPixelCount.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudRegionCaptureMagnifierPixelCount.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
+    <value>80, 22</value>
   </data>
   <data name="nudRegionCaptureMagnifierPixelCount.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -4660,10 +5179,13 @@
     <value>33</value>
   </data>
   <data name="nudRegionCaptureMagnifierPixelSize.Location" type="System.Drawing.Point, System.Drawing">
-    <value>312, 340</value>
+    <value>390, 425</value>
+  </data>
+  <data name="nudRegionCaptureMagnifierPixelSize.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudRegionCaptureMagnifierPixelSize.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
+    <value>80, 22</value>
   </data>
   <data name="nudRegionCaptureMagnifierPixelSize.TabIndex" type="System.Int32, mscorlib">
     <value>26</value>
@@ -4684,13 +5206,16 @@
     <value>34</value>
   </data>
   <data name="tpRegionCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpRegionCapture.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpRegionCapture.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpRegionCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 453</value>
+    <value>698, 566</value>
   </data>
   <data name="tpRegionCapture.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -4717,10 +5242,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbScreenRecordTransparentRegion.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 200</value>
+    <value>10, 250</value>
+  </data>
+  <data name="cbScreenRecordTransparentRegion.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbScreenRecordTransparentRegion.Size" type="System.Drawing.Size, System.Drawing">
-    <value>178, 17</value>
+    <value>236, 21</value>
   </data>
   <data name="cbScreenRecordTransparentRegion.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -4747,10 +5275,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbScreenRecordTwoPassEncoding.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 176</value>
+    <value>10, 220</value>
+  </data>
+  <data name="cbScreenRecordTwoPassEncoding.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbScreenRecordTwoPassEncoding.Size" type="System.Drawing.Size, System.Drawing">
-    <value>350, 17</value>
+    <value>465, 21</value>
   </data>
   <data name="cbScreenRecordTwoPassEncoding.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -4777,10 +5308,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbScreenRecordConfirmAbort.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 224</value>
+    <value>10, 280</value>
+  </data>
+  <data name="cbScreenRecordConfirmAbort.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbScreenRecordConfirmAbort.Size" type="System.Drawing.Size, System.Drawing">
-    <value>189, 17</value>
+    <value>248, 21</value>
   </data>
   <data name="cbScreenRecordConfirmAbort.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -4807,10 +5341,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbScreenRecorderShowCursor.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 104</value>
+    <value>10, 130</value>
+  </data>
+  <data name="cbScreenRecorderShowCursor.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbScreenRecorderShowCursor.Size" type="System.Drawing.Size, System.Drawing">
-    <value>143, 17</value>
+    <value>187, 21</value>
   </data>
   <data name="cbScreenRecorderShowCursor.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -4834,10 +5371,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnScreenRecorderFFmpegOptions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
+    <value>10, 10</value>
+  </data>
+  <data name="btnScreenRecorderFFmpegOptions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnScreenRecorderFFmpegOptions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>248, 32</value>
+    <value>310, 40</value>
   </data>
   <data name="btnScreenRecorderFFmpegOptions.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -4864,10 +5404,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblScreenRecorderStartDelay.Location" type="System.Drawing.Point, System.Drawing">
-    <value>304, 130</value>
+    <value>380, 162</value>
+  </data>
+  <data name="lblScreenRecorderStartDelay.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblScreenRecorderStartDelay.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>61, 17</value>
   </data>
   <data name="lblScreenRecorderStartDelay.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -4894,10 +5437,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbScreenRecordAutoStart.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 128</value>
+    <value>10, 160</value>
+  </data>
+  <data name="cbScreenRecordAutoStart.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbScreenRecordAutoStart.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 17</value>
+    <value>161, 21</value>
   </data>
   <data name="cbScreenRecordAutoStart.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -4924,10 +5470,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblScreenRecorderFixedDuration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>304, 154</value>
+    <value>380, 192</value>
+  </data>
+  <data name="lblScreenRecorderFixedDuration.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblScreenRecorderFixedDuration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 13</value>
+    <value>61, 17</value>
   </data>
   <data name="lblScreenRecorderFixedDuration.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -4948,10 +5497,13 @@
     <value>7</value>
   </data>
   <data name="nudScreenRecordFPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 52</value>
+    <value>290, 65</value>
+  </data>
+  <data name="nudScreenRecordFPS.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudScreenRecordFPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
+    <value>80, 22</value>
   </data>
   <data name="nudScreenRecordFPS.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -4978,10 +5530,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblScreenRecordFPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 56</value>
+    <value>10, 70</value>
+  </data>
+  <data name="lblScreenRecordFPS.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblScreenRecordFPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 13</value>
+    <value>151, 17</value>
   </data>
   <data name="lblScreenRecordFPS.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -5002,10 +5557,13 @@
     <value>9</value>
   </data>
   <data name="nudScreenRecorderDuration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 150</value>
+    <value>290, 188</value>
+  </data>
+  <data name="nudScreenRecorderDuration.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudScreenRecorderDuration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
+    <value>80, 22</value>
   </data>
   <data name="nudScreenRecorderDuration.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -5026,10 +5584,13 @@
     <value>10</value>
   </data>
   <data name="nudScreenRecorderStartDelay.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 126</value>
+    <value>290, 158</value>
+  </data>
+  <data name="nudScreenRecorderStartDelay.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudScreenRecorderStartDelay.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
+    <value>80, 22</value>
   </data>
   <data name="nudScreenRecorderStartDelay.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -5056,10 +5617,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbScreenRecorderFixedDuration.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 152</value>
+    <value>10, 190</value>
+  </data>
+  <data name="cbScreenRecorderFixedDuration.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbScreenRecorderFixedDuration.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 17</value>
+    <value>123, 21</value>
   </data>
   <data name="cbScreenRecorderFixedDuration.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -5080,10 +5644,13 @@
     <value>12</value>
   </data>
   <data name="nudGIFFPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>232, 76</value>
+    <value>290, 95</value>
+  </data>
+  <data name="nudGIFFPS.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudGIFFPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 20</value>
+    <value>80, 22</value>
   </data>
   <data name="nudGIFFPS.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -5110,10 +5677,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblGIFFPS.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 80</value>
+    <value>10, 100</value>
+  </data>
+  <data name="lblGIFFPS.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblGIFFPS.Size" type="System.Drawing.Size, System.Drawing">
-    <value>50, 13</value>
+    <value>64, 17</value>
   </data>
   <data name="lblGIFFPS.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -5134,13 +5704,16 @@
     <value>14</value>
   </data>
   <data name="tpScreenRecorder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpScreenRecorder.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpScreenRecorder.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpScreenRecorder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 453</value>
+    <value>698, 566</value>
   </data>
   <data name="tpScreenRecorder.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -5161,10 +5734,13 @@
     <value>2</value>
   </data>
   <data name="btnCaptureOCRHelp.Location" type="System.Drawing.Point, System.Drawing">
-    <value>224, 21</value>
+    <value>280, 26</value>
+  </data>
+  <data name="btnCaptureOCRHelp.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnCaptureOCRHelp.Size" type="System.Drawing.Size, System.Drawing">
-    <value>26, 26</value>
+    <value>32, 32</value>
   </data>
   <data name="btnCaptureOCRHelp.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -5188,10 +5764,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbCaptureOCRAutoCopy.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 80</value>
+    <value>10, 100</value>
+  </data>
+  <data name="cbCaptureOCRAutoCopy.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbCaptureOCRAutoCopy.Size" type="System.Drawing.Size, System.Drawing">
-    <value>205, 17</value>
+    <value>271, 21</value>
   </data>
   <data name="cbCaptureOCRAutoCopy.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -5215,10 +5794,13 @@
     <value>True</value>
   </data>
   <data name="cbCloseWindowAfterOpenServiceLink.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 103</value>
+    <value>10, 129</value>
+  </data>
+  <data name="cbCloseWindowAfterOpenServiceLink.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbCloseWindowAfterOpenServiceLink.Size" type="System.Drawing.Size, System.Drawing">
-    <value>238, 17</value>
+    <value>310, 21</value>
   </data>
   <data name="cbCloseWindowAfterOpenServiceLink.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -5245,10 +5827,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbCaptureOCRSilent.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 56</value>
+    <value>10, 70</value>
+  </data>
+  <data name="cbCaptureOCRSilent.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbCaptureOCRSilent.Size" type="System.Drawing.Size, System.Drawing">
-    <value>124, 17</value>
+    <value>162, 21</value>
   </data>
   <data name="cbCaptureOCRSilent.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -5275,10 +5860,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblOCRDefaultLanguage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 8</value>
+    <value>6, 10</value>
+  </data>
+  <data name="lblOCRDefaultLanguage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblOCRDefaultLanguage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>91, 13</value>
+    <value>120, 17</value>
   </data>
   <data name="lblOCRDefaultLanguage.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -5299,10 +5887,13 @@
     <value>4</value>
   </data>
   <data name="cbCaptureOCRDefaultLanguage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 24</value>
+    <value>10, 30</value>
+  </data>
+  <data name="cbCaptureOCRDefaultLanguage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbCaptureOCRDefaultLanguage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>208, 21</value>
+    <value>259, 24</value>
   </data>
   <data name="cbCaptureOCRDefaultLanguage.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -5320,13 +5911,16 @@
     <value>5</value>
   </data>
   <data name="tpOCR.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpOCR.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpOCR.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpOCR.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 453</value>
+    <value>698, 566</value>
   </data>
   <data name="tpOCR.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -5350,10 +5944,13 @@
     <value>Fill</value>
   </data>
   <data name="tcCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 4</value>
+  </data>
+  <data name="tcCapture.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tcCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>565, 479</value>
+    <value>708, 602</value>
   </data>
   <data name="tcCapture.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -5371,13 +5968,16 @@
     <value>0</value>
   </data>
   <data name="tpCapture.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpCapture.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpCapture.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpCapture.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 485</value>
+    <value>716, 610</value>
   </data>
   <data name="tpCapture.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -5409,11 +6009,14 @@
   <data name="cbOverrideUploadSettings.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="cbOverrideUploadSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
   <data name="cbOverrideUploadSettings.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 0</value>
+    <value>10, 10, 10, 0</value>
   </data>
   <data name="cbOverrideUploadSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 25</value>
+    <value>700, 31</value>
   </data>
   <data name="cbOverrideUploadSettings.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -5434,10 +6037,13 @@
     <value>0</value>
   </data>
   <data name="tpUploadMain.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpUploadMain.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpUploadMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 453</value>
+    <value>700, 573</value>
   </data>
   <data name="tpUploadMain.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -5455,10 +6061,13 @@
     <value>0</value>
   </data>
   <data name="txtURLRegexReplaceReplacement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 368</value>
+    <value>10, 460</value>
+  </data>
+  <data name="txtURLRegexReplaceReplacement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtURLRegexReplaceReplacement.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>439, 22</value>
   </data>
   <data name="txtURLRegexReplaceReplacement.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -5482,10 +6091,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblURLRegexReplaceReplacement.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 352</value>
+    <value>6, 440</value>
+  </data>
+  <data name="lblURLRegexReplaceReplacement.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblURLRegexReplaceReplacement.Size" type="System.Drawing.Size, System.Drawing">
-    <value>73, 13</value>
+    <value>95, 17</value>
   </data>
   <data name="lblURLRegexReplaceReplacement.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -5506,10 +6118,13 @@
     <value>1</value>
   </data>
   <data name="txtURLRegexReplacePattern.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 328</value>
+    <value>10, 410</value>
+  </data>
+  <data name="txtURLRegexReplacePattern.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtURLRegexReplacePattern.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>439, 22</value>
   </data>
   <data name="txtURLRegexReplacePattern.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -5533,10 +6148,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblURLRegexReplacePattern.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 312</value>
+    <value>6, 390</value>
+  </data>
+  <data name="lblURLRegexReplacePattern.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblURLRegexReplacePattern.Size" type="System.Drawing.Size, System.Drawing">
-    <value>44, 13</value>
+    <value>58, 17</value>
   </data>
   <data name="lblURLRegexReplacePattern.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -5563,10 +6181,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbURLRegexReplace.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 288</value>
+    <value>10, 360</value>
+  </data>
+  <data name="cbURLRegexReplace.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbURLRegexReplace.Size" type="System.Drawing.Size, System.Drawing">
-    <value>296, 17</value>
+    <value>395, 21</value>
   </data>
   <data name="cbURLRegexReplace.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -5590,10 +6211,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnAutoIncrementNumber.Location" type="System.Drawing.Point, System.Drawing">
-    <value>120, 176</value>
+    <value>150, 220</value>
+  </data>
+  <data name="btnAutoIncrementNumber.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnAutoIncrementNumber.Size" type="System.Drawing.Size, System.Drawing">
-    <value>96, 23</value>
+    <value>120, 29</value>
   </data>
   <data name="btnAutoIncrementNumber.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -5620,10 +6244,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblAutoIncrementNumber.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 160</value>
+    <value>6, 200</value>
+  </data>
+  <data name="lblAutoIncrementNumber.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblAutoIncrementNumber.Size" type="System.Drawing.Size, System.Drawing">
-    <value>119, 13</value>
+    <value>159, 17</value>
   </data>
   <data name="lblAutoIncrementNumber.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -5644,10 +6271,13 @@
     <value>6</value>
   </data>
   <data name="nudAutoIncrementNumber.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 177</value>
+    <value>10, 221</value>
+  </data>
+  <data name="nudAutoIncrementNumber.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="nudAutoIncrementNumber.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 20</value>
+    <value>130, 22</value>
   </data>
   <data name="nudAutoIncrementNumber.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -5674,10 +6304,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbFileUploadReplaceProblematicCharacters.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 264</value>
+    <value>10, 330</value>
+  </data>
+  <data name="cbFileUploadReplaceProblematicCharacters.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbFileUploadReplaceProblematicCharacters.Size" type="System.Drawing.Size, System.Drawing">
-    <value>370, 17</value>
+    <value>489, 21</value>
   </data>
   <data name="cbFileUploadReplaceProblematicCharacters.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -5704,10 +6337,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbNameFormatCustomTimeZone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 208</value>
+    <value>10, 260</value>
+  </data>
+  <data name="cbNameFormatCustomTimeZone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbNameFormatCustomTimeZone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>133, 17</value>
+    <value>173, 21</value>
   </data>
   <data name="cbNameFormatCustomTimeZone.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -5734,10 +6370,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblNameFormatPatternPreview.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 48</value>
+    <value>6, 60</value>
+  </data>
+  <data name="lblNameFormatPatternPreview.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblNameFormatPatternPreview.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 13</value>
+    <value>61, 17</value>
   </data>
   <data name="lblNameFormatPatternPreview.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -5764,10 +6403,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblNameFormatPatternActiveWindow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 72</value>
+    <value>6, 90</value>
+  </data>
+  <data name="lblNameFormatPatternActiveWindow.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblNameFormatPatternActiveWindow.Size" type="System.Drawing.Size, System.Drawing">
-    <value>167, 13</value>
+    <value>220, 17</value>
   </data>
   <data name="lblNameFormatPatternActiveWindow.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -5794,10 +6436,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblNameFormatPatternPreviewActiveWindow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 112</value>
+    <value>6, 140</value>
+  </data>
+  <data name="lblNameFormatPatternPreviewActiveWindow.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblNameFormatPatternPreviewActiveWindow.Size" type="System.Drawing.Size, System.Drawing">
-    <value>48, 13</value>
+    <value>61, 17</value>
   </data>
   <data name="lblNameFormatPatternPreviewActiveWindow.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -5818,10 +6463,13 @@
     <value>12</value>
   </data>
   <data name="cbNameFormatTimeZone.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 232</value>
+    <value>10, 290</value>
+  </data>
+  <data name="cbNameFormatTimeZone.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbNameFormatTimeZone.Size" type="System.Drawing.Size, System.Drawing">
-    <value>288, 21</value>
+    <value>359, 24</value>
   </data>
   <data name="cbNameFormatTimeZone.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -5839,10 +6487,13 @@
     <value>13</value>
   </data>
   <data name="txtNameFormatPatternActiveWindow.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 88</value>
+    <value>10, 110</value>
+  </data>
+  <data name="txtNameFormatPatternActiveWindow.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtNameFormatPatternActiveWindow.Size" type="System.Drawing.Size, System.Drawing">
-    <value>448, 20</value>
+    <value>559, 22</value>
   </data>
   <data name="txtNameFormatPatternActiveWindow.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -5866,10 +6517,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbFileUploadUseNamePattern.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 136</value>
+    <value>10, 170</value>
+  </data>
+  <data name="cbFileUploadUseNamePattern.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbFileUploadUseNamePattern.Size" type="System.Drawing.Size, System.Drawing">
-    <value>307, 17</value>
+    <value>409, 21</value>
   </data>
   <data name="cbFileUploadUseNamePattern.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -5896,10 +6550,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblNameFormatPattern.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 8</value>
+    <value>6, 10</value>
+  </data>
+  <data name="lblNameFormatPattern.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblNameFormatPattern.Size" type="System.Drawing.Size, System.Drawing">
-    <value>221, 13</value>
+    <value>297, 17</value>
   </data>
   <data name="lblNameFormatPattern.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -5920,10 +6577,13 @@
     <value>16</value>
   </data>
   <data name="txtNameFormatPattern.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 24</value>
+    <value>10, 30</value>
+  </data>
+  <data name="txtNameFormatPattern.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtNameFormatPattern.Size" type="System.Drawing.Size, System.Drawing">
-    <value>448, 20</value>
+    <value>559, 22</value>
   </data>
   <data name="txtNameFormatPattern.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -5941,13 +6601,16 @@
     <value>17</value>
   </data>
   <data name="tpFileNaming.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpFileNaming.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpFileNaming.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpFileNaming.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 453</value>
+    <value>698, 566</value>
   </data>
   <data name="tpFileNaming.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -5974,10 +6637,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbClipboardUploadShareURL.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 56</value>
+    <value>10, 70</value>
+  </data>
+  <data name="cbClipboardUploadShareURL.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbClipboardUploadShareURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>343, 17</value>
+    <value>453, 21</value>
   </data>
   <data name="cbClipboardUploadShareURL.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -6004,10 +6670,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbClipboardUploadURLContents.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
+    <value>10, 10</value>
+  </data>
+  <data name="cbClipboardUploadURLContents.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbClipboardUploadURLContents.Size" type="System.Drawing.Size, System.Drawing">
-    <value>308, 17</value>
+    <value>404, 21</value>
   </data>
   <data name="cbClipboardUploadURLContents.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -6034,10 +6703,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbClipboardUploadAutoIndexFolder.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 80</value>
+    <value>10, 100</value>
+  </data>
+  <data name="cbClipboardUploadAutoIndexFolder.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbClipboardUploadAutoIndexFolder.Size" type="System.Drawing.Size, System.Drawing">
-    <value>387, 17</value>
+    <value>513, 21</value>
   </data>
   <data name="cbClipboardUploadAutoIndexFolder.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -6064,10 +6736,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbClipboardUploadShortenURL.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 32</value>
+    <value>10, 40</value>
+  </data>
+  <data name="cbClipboardUploadShortenURL.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbClipboardUploadShortenURL.Size" type="System.Drawing.Size, System.Drawing">
-    <value>271, 17</value>
+    <value>356, 21</value>
   </data>
   <data name="cbClipboardUploadShortenURL.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -6088,13 +6763,16 @@
     <value>3</value>
   </data>
   <data name="tpUploadClipboard.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpUploadClipboard.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpUploadClipboard.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpUploadClipboard.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 453</value>
+    <value>698, 566</value>
   </data>
   <data name="tpUploadClipboard.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -6121,19 +6799,22 @@
     <value>Uploader</value>
   </data>
   <data name="chUploaderFiltersName.Width" type="System.Int32, mscorlib">
-    <value>128</value>
+    <value>160</value>
   </data>
   <data name="chUploaderFiltersExtension.Text" xml:space="preserve">
     <value>Extension</value>
   </data>
   <data name="chUploaderFiltersExtension.Width" type="System.Int32, mscorlib">
-    <value>98</value>
+    <value>122</value>
   </data>
   <data name="lvUploaderFiltersList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 136</value>
+    <value>10, 170</value>
+  </data>
+  <data name="lvUploaderFiltersList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="lvUploaderFiltersList.Size" type="System.Drawing.Size, System.Drawing">
-    <value>536, 310</value>
+    <value>669, 383</value>
   </data>
   <data name="lvUploaderFiltersList.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -6154,10 +6835,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnUploaderFiltersRemove.Location" type="System.Drawing.Point, System.Drawing">
-    <value>280, 104</value>
+    <value>350, 130</value>
+  </data>
+  <data name="btnUploaderFiltersRemove.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnUploaderFiltersRemove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>128, 23</value>
+    <value>160, 29</value>
   </data>
   <data name="btnUploaderFiltersRemove.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -6181,10 +6865,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnUploaderFiltersUpdate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>144, 104</value>
+    <value>180, 130</value>
+  </data>
+  <data name="btnUploaderFiltersUpdate.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnUploaderFiltersUpdate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>128, 23</value>
+    <value>160, 29</value>
   </data>
   <data name="btnUploaderFiltersUpdate.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -6208,10 +6895,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnUploaderFiltersAdd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 104</value>
+    <value>10, 130</value>
+  </data>
+  <data name="btnUploaderFiltersAdd.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnUploaderFiltersAdd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>128, 23</value>
+    <value>160, 29</value>
   </data>
   <data name="btnUploaderFiltersAdd.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -6238,10 +6928,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblUploaderFiltersDestination.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 8</value>
+    <value>6, 10</value>
+  </data>
+  <data name="lblUploaderFiltersDestination.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblUploaderFiltersDestination.Size" type="System.Drawing.Size, System.Drawing">
-    <value>53, 13</value>
+    <value>70, 17</value>
   </data>
   <data name="lblUploaderFiltersDestination.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -6262,10 +6955,13 @@
     <value>4</value>
   </data>
   <data name="cbUploaderFiltersDestination.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 24</value>
+    <value>10, 30</value>
+  </data>
+  <data name="cbUploaderFiltersDestination.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbUploaderFiltersDestination.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 21</value>
+    <value>439, 24</value>
   </data>
   <data name="cbUploaderFiltersDestination.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -6289,10 +6985,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblUploaderFiltersExtensionsExample.Location" type="System.Drawing.Point, System.Drawing">
-    <value>368, 76</value>
+    <value>460, 95</value>
+  </data>
+  <data name="lblUploaderFiltersExtensionsExample.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblUploaderFiltersExtensionsExample.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 13</value>
+    <value>155, 17</value>
   </data>
   <data name="lblUploaderFiltersExtensionsExample.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -6319,10 +7018,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblUploaderFiltersExtensions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 56</value>
+    <value>6, 70</value>
+  </data>
+  <data name="lblUploaderFiltersExtensions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblUploaderFiltersExtensions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>78, 13</value>
+    <value>104, 17</value>
   </data>
   <data name="lblUploaderFiltersExtensions.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -6343,10 +7045,13 @@
     <value>7</value>
   </data>
   <data name="txtUploaderFiltersExtensions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 72</value>
+    <value>10, 90</value>
+  </data>
+  <data name="txtUploaderFiltersExtensions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtUploaderFiltersExtensions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>352, 20</value>
+    <value>439, 22</value>
   </data>
   <data name="txtUploaderFiltersExtensions.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -6364,13 +7069,16 @@
     <value>8</value>
   </data>
   <data name="tpUploaderFilters.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpUploaderFilters.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpUploaderFilters.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpUploaderFilters.Size" type="System.Drawing.Size, System.Drawing">
-    <value>557, 453</value>
+    <value>698, 566</value>
   </data>
   <data name="tpUploaderFilters.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -6394,10 +7102,13 @@
     <value>Fill</value>
   </data>
   <data name="tcUpload.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 4</value>
+  </data>
+  <data name="tcUpload.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tcUpload.Size" type="System.Drawing.Size, System.Drawing">
-    <value>565, 479</value>
+    <value>708, 602</value>
   </data>
   <data name="tcUpload.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -6415,13 +7126,16 @@
     <value>0</value>
   </data>
   <data name="tpUpload.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpUpload.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpUpload.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpUpload.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 485</value>
+    <value>716, 610</value>
   </data>
   <data name="tpUpload.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -6445,10 +7159,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnActions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>392, 32</value>
+    <value>490, 40</value>
+  </data>
+  <data name="btnActions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnActions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 23</value>
+    <value>110, 29</value>
   </data>
   <data name="btnActions.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -6475,10 +7192,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblActionsNote.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 8</value>
+    <value>6, 10</value>
+  </data>
+  <data name="lblActionsNote.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblActionsNote.Size" type="System.Drawing.Size, System.Drawing">
-    <value>402, 13</value>
+    <value>532, 17</value>
   </data>
   <data name="lblActionsNote.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -6505,10 +7225,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnActionsDuplicate.Location" type="System.Drawing.Point, System.Drawing">
-    <value>200, 32</value>
+    <value>250, 40</value>
+  </data>
+  <data name="btnActionsDuplicate.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnActionsDuplicate.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 23</value>
+    <value>110, 29</value>
   </data>
   <data name="btnActionsDuplicate.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -6532,10 +7255,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnActionsAdd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 32</value>
+    <value>10, 40</value>
+  </data>
+  <data name="btnActionsAdd.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnActionsAdd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 23</value>
+    <value>110, 29</value>
   </data>
   <data name="btnActionsAdd.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -6562,31 +7288,34 @@
     <value>Name</value>
   </data>
   <data name="chActionsName.Width" type="System.Int32, mscorlib">
-    <value>90</value>
+    <value>112</value>
   </data>
   <data name="chActionsPath.Text" xml:space="preserve">
     <value>File path</value>
   </data>
   <data name="chActionsPath.Width" type="System.Int32, mscorlib">
-    <value>220</value>
+    <value>275</value>
   </data>
   <data name="chActionsArgs.Text" xml:space="preserve">
     <value>Arguments</value>
   </data>
   <data name="chActionsArgs.Width" type="System.Int32, mscorlib">
-    <value>114</value>
+    <value>142</value>
   </data>
   <data name="chActionsExtensions.Text" xml:space="preserve">
     <value>Extensions</value>
   </data>
   <data name="chActionsExtensions.Width" type="System.Int32, mscorlib">
-    <value>75</value>
+    <value>94</value>
   </data>
   <data name="lvActions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 64</value>
+    <value>10, 80</value>
+  </data>
+  <data name="lvActions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="lvActions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>552, 389</value>
+    <value>691, 489</value>
   </data>
   <data name="lvActions.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -6610,10 +7339,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnActionsEdit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>104, 32</value>
+    <value>130, 40</value>
+  </data>
+  <data name="btnActionsEdit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnActionsEdit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 23</value>
+    <value>110, 29</value>
   </data>
   <data name="btnActionsEdit.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -6640,10 +7372,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnActionsRemove.Location" type="System.Drawing.Point, System.Drawing">
-    <value>296, 32</value>
+    <value>370, 40</value>
+  </data>
+  <data name="btnActionsRemove.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnActionsRemove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 23</value>
+    <value>110, 29</value>
   </data>
   <data name="btnActionsRemove.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -6667,13 +7402,13 @@
     <value>Fill</value>
   </data>
   <data name="pActions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
+    <value>0, 31</value>
   </data>
   <data name="pActions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>0, 0, 0, 0</value>
   </data>
   <data name="pActions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 460</value>
+    <value>716, 579</value>
   </data>
   <data name="pActions.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -6702,11 +7437,14 @@
   <data name="cbOverrideActions.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="cbOverrideActions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
   <data name="cbOverrideActions.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 0</value>
+    <value>10, 10, 10, 0</value>
   </data>
   <data name="cbOverrideActions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 25</value>
+    <value>716, 31</value>
   </data>
   <data name="cbOverrideActions.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -6727,10 +7465,13 @@
     <value>1</value>
   </data>
   <data name="tpActions.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpActions.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpActions.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 485</value>
+    <value>716, 610</value>
   </data>
   <data name="tpActions.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -6754,10 +7495,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnWatchFolderEdit.Location" type="System.Drawing.Point, System.Drawing">
-    <value>104, 32</value>
+    <value>130, 40</value>
+  </data>
+  <data name="btnWatchFolderEdit.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnWatchFolderEdit.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 24</value>
+    <value>110, 30</value>
   </data>
   <data name="btnWatchFolderEdit.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -6784,10 +7528,13 @@
     <value>NoControl</value>
   </data>
   <data name="cbWatchFolderEnabled.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 8</value>
+    <value>10, 10</value>
+  </data>
+  <data name="cbWatchFolderEnabled.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbWatchFolderEnabled.Size" type="System.Drawing.Size, System.Drawing">
-    <value>266, 17</value>
+    <value>349, 21</value>
   </data>
   <data name="cbWatchFolderEnabled.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -6814,25 +7561,28 @@
     <value>Folder path</value>
   </data>
   <data name="chWatchFolderFolderPath.Width" type="System.Int32, mscorlib">
-    <value>323</value>
+    <value>404</value>
   </data>
   <data name="chWatchFolderFilter.Text" xml:space="preserve">
     <value>Filter</value>
   </data>
   <data name="chWatchFolderFilter.Width" type="System.Int32, mscorlib">
-    <value>43</value>
+    <value>54</value>
   </data>
   <data name="chWatchFolderIncludeSubdirectories.Text" xml:space="preserve">
     <value>Include subdirectories</value>
   </data>
   <data name="chWatchFolderIncludeSubdirectories.Width" type="System.Int32, mscorlib">
-    <value>182</value>
+    <value>228</value>
   </data>
   <data name="lvWatchFolderList.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 64</value>
+    <value>10, 80</value>
+  </data>
+  <data name="lvWatchFolderList.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="lvWatchFolderList.Size" type="System.Drawing.Size, System.Drawing">
-    <value>552, 414</value>
+    <value>689, 513</value>
   </data>
   <data name="lvWatchFolderList.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -6853,10 +7603,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnWatchFolderRemove.Location" type="System.Drawing.Point, System.Drawing">
-    <value>200, 32</value>
+    <value>250, 40</value>
+  </data>
+  <data name="btnWatchFolderRemove.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnWatchFolderRemove.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 23</value>
+    <value>110, 29</value>
   </data>
   <data name="btnWatchFolderRemove.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -6880,10 +7633,13 @@
     <value>NoControl</value>
   </data>
   <data name="btnWatchFolderAdd.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 32</value>
+    <value>10, 40</value>
+  </data>
+  <data name="btnWatchFolderAdd.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="btnWatchFolderAdd.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 23</value>
+    <value>110, 29</value>
   </data>
   <data name="btnWatchFolderAdd.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -6904,13 +7660,16 @@
     <value>4</value>
   </data>
   <data name="tpWatchFolders.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpWatchFolders.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpWatchFolders.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpWatchFolders.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 485</value>
+    <value>716, 610</value>
   </data>
   <data name="tpWatchFolders.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -6931,10 +7690,13 @@
     <value>6</value>
   </data>
   <data name="txtToolsScreenColorPickerFormatCtrl.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 71</value>
+    <value>10, 89</value>
+  </data>
+  <data name="txtToolsScreenColorPickerFormatCtrl.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtToolsScreenColorPickerFormatCtrl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>288, 20</value>
+    <value>359, 22</value>
   </data>
   <data name="txtToolsScreenColorPickerFormatCtrl.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -6958,10 +7720,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblToolsScreenColorPickerFormatCtrl.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 55</value>
+    <value>6, 69</value>
+  </data>
+  <data name="lblToolsScreenColorPickerFormatCtrl.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblToolsScreenColorPickerFormatCtrl.Size" type="System.Drawing.Size, System.Drawing">
-    <value>192, 13</value>
+    <value>256, 17</value>
   </data>
   <data name="lblToolsScreenColorPickerFormatCtrl.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -6982,10 +7747,13 @@
     <value>1</value>
   </data>
   <data name="txtToolsScreenColorPickerInfoText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 118</value>
+    <value>10, 148</value>
+  </data>
+  <data name="txtToolsScreenColorPickerInfoText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtToolsScreenColorPickerInfoText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>288, 20</value>
+    <value>359, 22</value>
   </data>
   <data name="txtToolsScreenColorPickerInfoText.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -7009,10 +7777,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblToolsScreenColorPickerInfoText.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 102</value>
+    <value>6, 128</value>
+  </data>
+  <data name="lblToolsScreenColorPickerInfoText.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblToolsScreenColorPickerInfoText.Size" type="System.Drawing.Size, System.Drawing">
-    <value>142, 13</value>
+    <value>187, 17</value>
   </data>
   <data name="lblToolsScreenColorPickerInfoText.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -7033,10 +7804,13 @@
     <value>3</value>
   </data>
   <data name="txtToolsScreenColorPickerFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 24</value>
+    <value>10, 30</value>
+  </data>
+  <data name="txtToolsScreenColorPickerFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="txtToolsScreenColorPickerFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>288, 20</value>
+    <value>359, 22</value>
   </data>
   <data name="txtToolsScreenColorPickerFormat.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -7060,10 +7834,13 @@
     <value>NoControl</value>
   </data>
   <data name="lblToolsScreenColorPickerFormat.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 8</value>
+    <value>6, 10</value>
+  </data>
+  <data name="lblToolsScreenColorPickerFormat.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="lblToolsScreenColorPickerFormat.Size" type="System.Drawing.Size, System.Drawing">
-    <value>134, 13</value>
+    <value>178, 17</value>
   </data>
   <data name="lblToolsScreenColorPickerFormat.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -7087,10 +7864,13 @@
     <value>Fill</value>
   </data>
   <data name="pTools.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 25</value>
+    <value>0, 31</value>
+  </data>
+  <data name="pTools.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="pTools.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 460</value>
+    <value>716, 579</value>
   </data>
   <data name="pTools.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -7119,11 +7899,14 @@
   <data name="cbOverrideToolsSettings.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="cbOverrideToolsSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
+  </data>
   <data name="cbOverrideToolsSettings.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 0</value>
+    <value>10, 10, 10, 0</value>
   </data>
   <data name="cbOverrideToolsSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 25</value>
+    <value>716, 31</value>
   </data>
   <data name="cbOverrideToolsSettings.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -7144,10 +7927,13 @@
     <value>1</value>
   </data>
   <data name="tpTools.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpTools.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpTools.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 485</value>
+    <value>716, 610</value>
   </data>
   <data name="tpTools.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -7171,10 +7957,13 @@
     <value>Fill</value>
   </data>
   <data name="pgTaskSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 33</value>
+    <value>4, 41</value>
+  </data>
+  <data name="pgTaskSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="pgTaskSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>565, 449</value>
+    <value>708, 565</value>
   </data>
   <data name="pgTaskSettings.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -7201,13 +7990,16 @@
     <value>NoControl</value>
   </data>
   <data name="cbOverrideAdvancedSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 4</value>
+  </data>
+  <data name="cbOverrideAdvancedSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="cbOverrideAdvancedSettings.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 5, 5, 8</value>
+    <value>6, 6, 6, 10</value>
   </data>
   <data name="cbOverrideAdvancedSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>565, 30</value>
+    <value>708, 37</value>
   </data>
   <data name="cbOverrideAdvancedSettings.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -7228,13 +8020,16 @@
     <value>1</value>
   </data>
   <data name="tpAdvanced.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 25</value>
+  </data>
+  <data name="tpAdvanced.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpAdvanced.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tpAdvanced.Size" type="System.Drawing.Size, System.Drawing">
-    <value>571, 485</value>
+    <value>716, 610</value>
   </data>
   <data name="tpAdvanced.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -7258,10 +8053,13 @@
     <value>Right</value>
   </data>
   <data name="tcTaskSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>205, 0</value>
+    <value>256, 0</value>
+  </data>
+  <data name="tcTaskSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="tcTaskSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>579, 511</value>
+    <value>724, 639</value>
   </data>
   <data name="tcTaskSettings.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -7291,7 +8089,7 @@
     <value>0, 0, 0, 0</value>
   </data>
   <data name="tttvMain.Size" type="System.Drawing.Size, System.Drawing">
-    <value>784, 511</value>
+    <value>980, 639</value>
   </data>
   <data name="tttvMain.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -7312,13 +8110,16 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>96, 96</value>
+    <value>120, 120</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>784, 511</value>
+    <value>980, 639</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 4, 4, 4</value>
   </data>
   <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>800, 550</value>
+    <value>996, 676</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterScreen</value>

--- a/ShareX/ScreenRecordManager.cs
+++ b/ShareX/ScreenRecordManager.cs
@@ -276,6 +276,7 @@ namespace ShareX
 
                             Screenshot screenshot = TaskHelpers.GetScreenshot(taskSettings);
                             screenshot.CaptureCursor = taskSettings.CaptureSettings.ScreenRecordShowCursor;
+                            screenshot.UseWinRTCaptureAPI = taskSettings.CaptureSettings.UseWinRTGraphicsCaptureAPI;
 
                             screenRecorder?.Dispose();
                             screenRecorder = new ScreenRecorder(ScreenRecordOutput.FFmpeg, options, screenshot, captureRectangle);

--- a/ShareX/TaskHelpers.cs
+++ b/ShareX/TaskHelpers.cs
@@ -1933,7 +1933,8 @@ namespace ShareX
                 RemoveOutsideScreenArea = true,
                 CaptureShadow = taskSettings.CaptureSettings.CaptureShadow,
                 ShadowOffset = taskSettings.CaptureSettings.CaptureShadowOffset,
-                AutoHideTaskbar = taskSettings.CaptureSettings.CaptureAutoHideTaskbar
+                AutoHideTaskbar = taskSettings.CaptureSettings.CaptureAutoHideTaskbar,
+                UseWinRTCaptureAPI = taskSettings.CaptureSettings.UseWinRTGraphicsCaptureAPI,
             };
 
             return screenshot;

--- a/ShareX/TaskSettings.cs
+++ b/ShareX/TaskSettings.cs
@@ -380,6 +380,7 @@ namespace ShareX
         public bool CaptureAutoHideTaskbar = false;
         public Rectangle CaptureCustomRegion = new Rectangle(0, 0, 0, 0);
         public string CaptureCustomWindow = "";
+        public bool UseWinRTGraphicsCaptureAPI = false;
 
         #endregion Capture / General
 


### PR DESCRIPTION
In Windows 11, a yellow line appears around the edge of the screen if HDR is enabled and a screenshot is taken. These lines of code remove the yellow line.